### PR TITLE
Don't install openssh-sftp-server on Debian

### DIFF
--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -2,7 +2,6 @@
 sshd_service: ssh
 sshd_packages:
   - openssh-server
-  - openssh-sftp-server
 sshd_config_mode: "0644"
 sshd_defaults:
   Port: 22


### PR DESCRIPTION
Installing <code>openssh-sftp-server</code> on Debian Wheezy removes <code>openssh-server</code> so it's impossible to connect again via SSH:

    richard@server:~$ sudo apt-get install openssh-sftp-server
    Reading package lists... Done
    Building dependency tree       
    Reading state information... Done
    The following packages will be REMOVED:
      openssh-server
    The following NEW packages will be installed:
      openssh-sftp-server
    0 upgraded, 1 newly installed, 1 to remove and 94 not upgraded.
    Need to get 0 B/34.4 kB of archives.
    After this operation, 605 kB disk space will be freed.
    Do you want to continue [Y/n]? 
