### PR TITLE
Remove apt role dependancy

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -24,6 +24,4 @@ galaxy_info:
   categories:
   - networking
   - system
-dependencies:
-  - role: willshersystems.apt
-    when: ansible_pkg_mgr == 'apt' and apt_has_run is not defined
+dependencies: []


### PR DESCRIPTION
I'd like to remove the apt role dependency as ansible-playbook doesn't evaluate the when statement in meta/main.yml when checking for installed role dependancies, so the apt role must be installed even when not managing any apt systems. It doesn't appear this sshd roles requires any functionality in the apt role explicitly.