### PR TITLE
Make the role more container friendly

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,18 @@ If set to True, don't apply default values. This means that you must have a
 complete set of configuration defaults via either the sshd dict, or sshd_Key
 variables. Defaults to *False*.
 
+* sshd_manage_service
+
+If set to False, the service/daemon won't be touched at all, i.e. will not try
+to enable on boot or start or reload the service.  Defaults to *True* unless
+running inside a docker container (it is assumed ansible is used during build
+phase).
+
 * sshd_allow_reload
 
 If set to False, a reload of sshd wont happen on change. This can help with
 troubleshooting. You'll need to manually reload sshd if you want to apply the
-changed configuration. Defaults to *True*.
+changed configuration. Defaults to the same value as ``sshd_manage_service``.
 
 * sshd
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,8 +2,11 @@
 ### USER OPTIONS
 # Don't apply OS defaults when set to true
 sshd_skip_defaults: false
+# If the below is false, don't manage the service or reload the SSH
+# daemon at all
+sshd_manage_service: "{{ False if ansible_virtualization_type == 'docker' else True }}"
 # If the below is false, don't reload the ssh deamon on change
-sshd_allow_reload: yes
+sshd_allow_reload: "{{ sshd_manage_service }}"
 # Empty dicts to avoid errors
 sshd: {}
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,6 +23,14 @@
   tags:
     - sshd
 
+- name: Run directory
+  file:
+    path: /var/run/sshd
+    state: directory
+    mode: 0755
+  tags:
+    - sshd
+
 - name: Configuration
   template:
     src: sshd_config.j2

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -39,6 +39,7 @@
     name: "{{ sshd_service }}"
     enabled: true
     state: running
+  when: sshd_manage_service
   tags:
     - sshd
 


### PR DESCRIPTION
Allow skipping service management entirely and ensure privilege separation directory exists.

This makes it more container friendly as service management isn't necessarily used there (especially in docker) and privilege separation directory is usually created by the service scripts on start.
