### PR TITLE
Add Fedora support

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Tested on:
 * Debian wheezy, jessie
 * FreeBSD 10.1
 * EL 6,7 derived distributions
+* Fedora 20, 22
 
 It will likely work on other flavours and more direct support via suitable
 [vars/](vars/) files is welcome.

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -21,6 +21,10 @@ galaxy_info:
     versions:
     - 6
     - 7
+  - name: Fedora
+    versions:
+    - 20
+    - 22
   categories:
   - networking
   - system

--- a/vars/Fedora.yml
+++ b/vars/Fedora.yml
@@ -1,0 +1,25 @@
+---
+sshd_packages:
+  - openssh
+  - openssh-server
+sshd_sftp_server: /usr/libexec/openssh/sftp-server
+sshd_defaults:
+  HostKey:
+    - /etc/ssh/ssh_host_rsa_key
+    - /etc/ssh/ssh_host_ecdsa_key
+  SyslogFacility: AUTHPRIV
+  AuthorizedKeysFile: .ssh/authorized_keys
+  PasswordAuthentication: yes
+  ChallengeResponseAuthentication: no
+  GSSAPIAuthentication: yes
+  GSSAPICleanupCredentials: no
+  UsePAM: yes
+  X11Forwarding: yes
+  UsePrivilegeSeparation: sandbox
+  AcceptEnv:
+    - LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES
+    - LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT
+    - LC_IDENTIFICATION LC_ALL LANGUAGE
+    - XMODIFIERS
+  Subsystem: "sftp {{ sshd_sftp_server }}"
+sshd_os_supported: yes

--- a/vars/Fedora_22.yml
+++ b/vars/Fedora_22.yml
@@ -1,0 +1,26 @@
+---
+sshd_packages:
+  - openssh
+  - openssh-server
+sshd_sftp_server: /usr/libexec/openssh/sftp-server
+sshd_defaults:
+  HostKey:
+    - /etc/ssh/ssh_host_rsa_key
+    - /etc/ssh/ssh_host_ecdsa_key
+    - /etc/ssh/ssh_host_ed25519_key
+  SyslogFacility: AUTHPRIV
+  AuthorizedKeysFile: .ssh/authorized_keys
+  PasswordAuthentication: yes
+  ChallengeResponseAuthentication: no
+  GSSAPIAuthentication: yes
+  GSSAPICleanupCredentials: no
+  UsePAM: yes
+  X11Forwarding: yes
+  UsePrivilegeSeparation: sandbox
+  AcceptEnv:
+    - LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES
+    - LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT
+    - LC_IDENTIFICATION LC_ALL LANGUAGE
+    - XMODIFIERS
+  Subsystem: "sftp {{ sshd_sftp_server }}"
+sshd_os_supported: yes


### PR DESCRIPTION
Based on RedHat 7 with few modifications (ed25519 hostkey for F22,
GSSAPICleanupCredentials defaults to no, s/LC_TYPE/LC_CTYPE/ in
AcceptEnv).

Tested on Fedora 20 & 22.