### PR TITLE
Verify SSHd config early

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,8 +1,4 @@
 ---
-- name: check_and_reload_sshd
-  command: "{{ sshd_binary }} -t"
-  notify: reload_sshd
-
 - name: reload_sshd
   service:
     name: "{{ sshd_service }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -38,7 +38,8 @@
     owner: "{{ sshd_config_owner }}"
     group: "{{ sshd_config_group }}"
     mode: "{{ sshd_config_mode }}"
-  notify: check_and_reload_sshd
+    validate: "{{ sshd_binary }} -t -f %s"
+  notify: reload_sshd
   tags:
     - sshd
 


### PR DESCRIPTION
This uses the validate option to check the config file early, which
avoids putting bad settings in place at all, and also enables a
fail-fast behaviour (errors out when processing the template module).