### PR TITLE
fix deprecation warning for sshd_packages (fixes issue #38)

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,7 +21,7 @@
     {{ ansible_pkg_mgr }}
     name="{{ item }}"
     state=installed
-  with_items: sshd_packages
+  with_items: "{{ sshd_packages }}"
   tags:
     - sshd
 


### PR DESCRIPTION
This change fixes the ansible deprecation warning for bare word "sshd_packages" (issue #38).

(I tripped over it independently, but then found the issue already logged :)