### PR TITLE
show xenial support on galaxy

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -14,6 +14,7 @@ galaxy_info:
     versions:
     - precise
     - trusty
+    - xenial
   - name: FreeBSD
     version:
     - 10.1


### PR DESCRIPTION
This role is 16.04 compatible but isn't showing up as such on Galaxy.

Have updated `meta/main.yml` so this is no longer the case.