### PR TITLE
Support for OpenBSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Tested on:
 * FreeBSD 10.1
 * EL 6,7 derived distributions
 * Fedora 22, 23
+* OpenBSD 6.0
 
 It will likely work on other flavours and more direct support via suitable
 [vars/](vars/) files is welcome.

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -26,10 +26,13 @@ galaxy_info:
     versions:
     - 22
     - 23
+  - name: OpenBSD
+    versions:
+    - 6.0
   galaxy_tags:
   - networking
   - system
-  - SSH 
+  - SSH
   - OpenSSH
   - sshd
   - server
@@ -38,4 +41,5 @@ galaxy_info:
   - centos
   - redhat
   - freebsd
+  - openbsd
 dependencies: []

--- a/vars/OpenBSD.yml
+++ b/vars/OpenBSD.yml
@@ -1,0 +1,9 @@
+---
+sshd_config_group: wheel
+sshd_config_mode: "0600"
+sshd_sftp_server: /usr/libexec/sftp-server
+sshd_defaults:
+  AuthorizedKeysFile: .ssh/authorized_keys
+  Subsystem: "sftp {{ sshd_sftp_server }}"
+sshd_os_supported: yes
+sshd_manage_var_run: no


### PR DESCRIPTION
This was tested on OpenBSD 6.0 and `-current` with Ansible 2.1.2.0 and 2.2.0.0-rc1.