### PR TITLE
Don't fail without package manager

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,6 +22,7 @@
     name="{{ item }}"
     state=installed
   with_items: "{{ sshd_packages }}"
+  when: ansible_pkg_mgr != 'unknown'
   tags:
     - sshd
 


### PR DESCRIPTION
Atomic Host uses unsupported package manager `rpm-ostree`. So, `ansible_pkg_mgr` is `unknown` and this task will fail. `sshd` is already in base system images. Apart from this, sshd configuration is standard for Fedora/CentOS.

I'm not sure it's the right solution. May be it's better to create new boolean variable like `sshd_manage_install` and use it here in `when`.