### PR TITLE
clean Archlinux support to match the current package (openssh-7.4p1-2)

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,7 +8,7 @@ sshd_manage_service: "{{ false if ansible_virtualization_type == 'docker' else t
 # If the below is false, don't reload the ssh deamon on change
 sshd_allow_reload: "{{ sshd_manage_service }}"
 # If the below is false, don't manage /var/run/sshd directory
-sshd_manage_var_run: "{{ false if ansible_os_family == 'RedHat' and ansible_distribution_major_version == '7' else true }}"
+sshd_manage_var_run: "{{ false if ansible_os_family == 'Archlinux' or (ansible_os_family == 'RedHat' and ansible_distribution_major_version == '7') else true }}"
 # Empty dicts to avoid errors
 sshd: {}
 

--- a/vars/Archlinux.yml
+++ b/vars/Archlinux.yml
@@ -1,15 +1,11 @@
 ---
-sshd_service: sshd
 sshd_packages:
   - openssh
 sshd_sftp_server: /usr/lib/ssh/sftp-server
 sshd_defaults:
-  Port: 22
-  Protocol: 2
   AuthorizedKeysFile: .ssh/authorized_keys
   ChallengeResponseAuthentication: no
   PrintMotd: no
   Subsystem: "sftp {{ sshd_sftp_server }}"
   UsePAM: yes
-  UsePrivilegeSeparation: sandbox
 sshd_os_supported: yes


### PR DESCRIPTION
This is mostly a cosmetic change. It modifies the role to match the current OpenSSH version on Archlinux (7.4p1-2 as of this writing):

- automatically disable management of /var/run/sshd (not used on Archlinux)
- remove variables set in vars/Archlinux.yml that are not currently set in the distributed config
- remove sshd_service set in vars/Archlinux.yml because it is identical to defaults/main.yml
