### PR TITLE
Fix handler state

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,5 +2,5 @@
 - name: reload_sshd
   service:
     name: "{{ sshd_service }}"
-    state: reloaded
+    state: restarted
   when: sshd_allow_reload


### PR DESCRIPTION
Hi, me again. I've been facing this issue.
Symptom: 
- On the first run, the status of the play _Service enabled and running_ is **ok**, and the status of the handler _reload_sshd_ is **changed**. When I check on the target node, sshd is inactive (dead).
- On the second run, the status of the play is **changed**; sshd is active (running) now, but there's some error 

> error bind to port 22 on 0.0.0.0 failed address already in use 
- I tested manually on some random node and found out that if I _reload_ sshd when it's running, it'll always fail. But if I _restart_ it, it'll always succeed.
So this is my proposed fix. We're using CentOS here, and it works fine for us. I hope it's also ok for other distros.