### PR TITLE
Fixed sshd_match blocks

### DIFF
--- a/templates/sshd_config.j2
+++ b/templates/sshd_config.j2
@@ -162,29 +162,29 @@ Match {{ match["Condition"] }}
 {{ match_block(sshd_match) -}}
 {% endif %}
 {% if sshd_match_1 is defined %}
-{{ match_block(sshd_match) -}}
+{{ match_block(sshd_match_1) -}}
 {% endif %}
 {% if sshd_match_2 is defined %}
-{{ match_block(sshd_match) -}}
+{{ match_block(sshd_match_2) -}}
 {% endif %}
 {% if sshd_match_3 is defined %}
-{{ match_block(sshd_match) -}}
+{{ match_block(sshd_match_3) -}}
 {% endif %}
 {% if sshd_match_4 is defined %}
-{{ match_block(sshd_match) -}}
+{{ match_block(sshd_match_4) -}}
 {% endif %}
 {% if sshd_match_5 is defined %}
-{{ match_block(sshd_match) -}}
+{{ match_block(sshd_match_5) -}}
 {% endif %}
 {% if sshd_match_6 is defined %}
-{{ match_block(sshd_match) -}}
+{{ match_block(sshd_match_6) -}}
 {% endif %}
 {% if sshd_match_7 is defined %}
-{{ match_block(sshd_match) -}}
+{{ match_block(sshd_match_7) -}}
 {% endif %}
 {% if sshd_match_8 is defined %}
-{{ match_block(sshd_match) -}}
+{{ match_block(sshd_match_8) -}}
 {% endif %}
 {% if sshd_match_9 is defined %}
-{{ match_block(sshd_match) -}}
+{{ match_block(sshd_match_9) -}}
 {% endif %}


### PR DESCRIPTION
This fixes the sshd_match blocks to use the contents of the matching block rather than re-using the original sshd_match block repeatedly.