### PR TITLE
Removes tags

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,14 +7,10 @@
    - "{{ ansible_os_family }}_{{ ansible_distribution_major_version }}.yml"
    - "{{ ansible_os_family }}.yml"
    - default.yml
-  tags:
-    - sshd
 
 - name: OS is supported
   assert:
     that: sshd_os_supported == True
-  tags:
-    - sshd
 
 - name: Installed
   action: >
@@ -23,8 +19,6 @@
     state=installed
   with_items: "{{ sshd_packages }}"
   when: ansible_pkg_mgr != 'unknown'
-  tags:
-    - sshd
 
 - name: Configuration
   template:
@@ -35,8 +29,6 @@
     mode: "{{ sshd_config_mode }}"
     validate: "{{ sshd_binary }} -t -f %s"
   notify: reload_sshd
-  tags:
-    - sshd
 
 - name: Service enabled and running
   service:
@@ -44,11 +36,7 @@
     enabled: true
     state: started
   when: sshd_manage_service and ansible_virtualization_type != 'docker'
-  tags:
-    - sshd
 
 - name: Register that this role has run
   set_fact: sshd_has_run=true
   when: sshd_has_run is not defined
-  tags:
-    - sshd


### PR DESCRIPTION
I think it is not the best practice to include tags in the role tasks. This could conflict with user tags. Also, there is no benefit in tagging every task in the role as this could be easily achieved by the user of the role simply by adding a tag in their playbook. This PR does simply that.

Moreover, if you still believe that there is ground for including the tag in the role, it would be much cleaner to have an import_tasks/include_tasks statement in tasks/main.yml where the task could be applied and then have the rest of the tasks in the included file without any tags. 