### PR TITLE
Makes handler use listen:

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,6 +1,7 @@
 ---
-- name: reload_sshd
+- name: Reload the SSH service
   service:
     name: "{{ sshd_service }}"
     state: reloaded
   when: sshd_allow_reload and ansible_virtualization_type != 'docker'
+  listen: reload_sshd


### PR DESCRIPTION
Using the `listen:` option in handlers has the benefits of producing more user friendly output (task names) and allowing multiple handlers listen to the same event.