### PR TITLE
add default Ubuntu vars, prepend role_path for bug avoidance

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,11 +2,11 @@
 - name: Set OS dependent variables
   include_vars: "{{ item }}"
   with_first_found:
-   - "{{ ansible_distribution }}_{{ ansible_distribution_major_version }}.yml"
-   - "{{ ansible_distribution }}.yml"
-   - "{{ ansible_os_family }}_{{ ansible_distribution_major_version }}.yml"
-   - "{{ ansible_os_family }}.yml"
-   - default.yml
+   - "{{ role_path }}/vars/{{ ansible_distribution }}_{{ ansible_distribution_major_version }}.yml"
+   - "{{ role_path }}/vars/{{ ansible_distribution }}.yml"
+   - "{{ role_path }}/vars/{{ ansible_os_family }}_{{ ansible_distribution_major_version }}.yml"
+   - "{{ role_path }}/vars/{{ ansible_os_family }}.yml"
+   - "{{ role_path }}/vars/default.yml"
 
 - name: OS is supported
   assert:

--- a/vars/Ubuntu.yml
+++ b/vars/Ubuntu.yml
@@ -1,0 +1,40 @@
+---
+sshd_service: ssh
+sshd_packages:
+  - openssh-server
+  - openssh-sftp-server
+sshd_config_mode: "0644"
+sshd_defaults:
+  Port: 22
+  Protocol: 2
+  HostKey:
+    - /etc/ssh/ssh_host_rsa_key
+    - /etc/ssh/ssh_host_dsa_key
+    - /etc/ssh/ssh_host_ecdsa_key
+    - /etc/ssh/ssh_host_ed25519_key
+  UsePrivilegeSeparation: yes
+  KeyRegenerationInterval: 3600
+  ServerKeyBits: 1024
+  SyslogFacility: AUTH
+  LogLevel: INFO
+  LoginGraceTime: 120
+  PermitRootLogin: prohibit-password
+  StrictModes: yes
+  RSAAuthentication: yes
+  PubkeyAuthentication: yes
+  AuthorizedKeysFile: "%h/.ssh/authorized_keys"
+  IgnoreRhosts: yes
+  RhostsRSAAuthentication: no
+  HostbasedAuthentication: no
+  PermitEmptyPasswords: no
+  ChallengeResponseAuthentication: no
+  X11Forwarding: yes
+  X11DisplayOffset: 10
+  PrintMotd: no
+  PrintLastLog: yes
+  TCPKeepAlive: yes
+  AcceptEnv: LANG LC_*
+  Subsystem: "sftp {{ sshd_sftp_server }}"
+  UsePAM: yes
+  UseDNS: no
+sshd_os_supported: yes


### PR DESCRIPTION
I'm trying to use Ubuntu 17.10 (which was not supported), and another role's vars/ kept being evaluated even after I added Ubuntu.yml. These changes fix both of those issues.

Thanks for considering these changes!