### PR TITLE
Fix Arch Linux var file

### DIFF
--- a/vars/Arch Linux.yml
+++ b/vars/Arch Linux.yml
@@ -1,0 +1,1 @@
+Archlinux.yml


### PR DESCRIPTION
Hi,

My `ansible_os_family` var had the value `Arch Linux`. I symlinked the existing vars file accordingly.