### PR TITLE
Add configuration append capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,11 @@ If set to False, a reload of sshd wont happen on change. This can help with
 troubleshooting. You'll need to manually reload sshd if you want to apply the
 changed configuration. Defaults to the same value as ``sshd_manage_service``.
 
+* sshd_append_configuration
+
+If set to True, configuration will be append to existing one instead of overriding it.
+This allows the use of other roles that update SSH configuration (e.g sftp roles, ...) while preserving idempotency.
+
 * sshd
 
 A dict containing configuration.  e.g.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,3 +23,7 @@ sshd_service: sshd
 sshd_sftp_server: /usr/lib/openssh/sftp-server
 sshd_defaults: {}
 sshd_os_supported: no
+
+# Override whole SSH configuration or just append to existing one.
+# This allows the use of other roles that update SSH configuration (e.g sftp roles, ...) while preserving idempotency.
+sshd_append_configuration: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,16 +17,40 @@
     name: "{{ item }}"
     state: present
   with_items: "{{ sshd_packages }}"
+  register: ssh_installation
+
+- name: Compute configuration
+  set_fact:
+    sshd_configuration: "{{ lookup('template', 'sshd_config.j2') }}"
 
 - name: Configuration
-  template:
-    src: sshd_config.j2
+  copy:
+    content: "{{ sshd_configuration }}"
     dest: "{{ sshd_config_file }}"
     owner: "{{ sshd_config_owner }}"
     group: "{{ sshd_config_group }}"
     mode: "{{ sshd_config_mode }}"
     validate: "{{ sshd_binary }} -t -f %s"
   notify: reload_sshd
+  when: not sshd_append_configuration
+
+- name: Remove default configuration
+  file:
+    path: "{{ sshd_config_file }}"
+    state: absent
+  when: sshd_append_configuration and ssh_installation | changed
+
+- name: Append configuration
+  blockinfile:
+    block: "{{ sshd_configuration }}"
+    dest: "{{ sshd_config_file }}"
+    create: true
+    owner: "{{ sshd_config_owner }}"
+    group: "{{ sshd_config_group }}"
+    mode: "{{ sshd_config_mode }}"
+    validate: "{{ sshd_binary }} -t -f %s"
+  notify: reload_sshd
+  when: sshd_append_configuration
 
 - name: Service enabled and running
   service:


### PR DESCRIPTION
To allow the use of other roles that update SSH configuration (like sftp
roles) while preserving idempotency.