### PR TITLE
Add StreamLocalBindUnlink option

### DIFF
--- a/meta/options_body
+++ b/meta/options_body
@@ -69,6 +69,7 @@ RekeyLimit
 RevokedKeys
 RhostsRSAAuthentication
 ServerKeyBits
+StreamLocalBindUnlink
 StrictModes
 Subsystem
 SyslogFacility

--- a/templates/sshd_config.j2
+++ b/templates/sshd_config.j2
@@ -140,6 +140,7 @@ Match {{ match["Condition"] }}
 {{ body_option("RevokedKeys",sshd_RevokedKeys) -}}
 {{ body_option("RhostsRSAAuthentication",sshd_RhostsRSAAuthentication) -}}
 {{ body_option("ServerKeyBits",sshd_ServerKeyBits) -}}
+{{ body_option("StreamLocalBindUnlink",sshd_StreamLocalBindUnlink) -}}
 {{ body_option("StrictModes",sshd_StrictModes) -}}
 {{ body_option("Subsystem",sshd_Subsystem) -}}
 {{ body_option("SyslogFacility",sshd_SyslogFacility) -}}


### PR DESCRIPTION
This option removes existing Unix-domain socket files before they are
used for forwarding targets.

Needed to support gpg-agent forwarding with systemd