### PR TITLE
Remove Deprecated options in default SSH config

### DIFF
--- a/vars/Debian_9.yml
+++ b/vars/Debian_9.yml
@@ -13,17 +13,13 @@ sshd_defaults:
     - /etc/ssh/ssh_host_ecdsa_key
     - /etc/ssh/ssh_host_ed25519_key
   UsePrivilegeSeparation: yes
-  KeyRegenerationInterval: 3600
-  ServerKeyBits: 1024
   SyslogFacility: AUTH
   LogLevel: INFO
   LoginGraceTime: 120
   PermitRootLogin: without-password
   StrictModes: yes
-  RSAAuthentication: yes
   PubkeyAuthentication: yes
   IgnoreRhosts: yes
-  RhostsRSAAuthentication: no
   HostbasedAuthentication: no
   PermitEmptyPasswords: no
   ChallengeResponseAuthentication: no


### PR DESCRIPTION
OpenSSH developers have deprectated these options in OpenSSH 7.4 (which Debian 9 uses), this PR removes the options from the Debian9 config.

Stackexchange reference: https://unix.stackexchange.com/questions/337774/deprecated-options-when-restarting-openssh-in-stretch