### PR TITLE
Fix for ansible_virtualization_type not being defined in Ansible > 2.5

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,5 +3,5 @@
   service:
     name: "{{ sshd_service }}"
     state: reloaded
-  when: sshd_allow_reload and ansible_virtualization_type != 'docker'
+  when: "sshd_allow_reload and ansible_virtualization_type|default(None) != 'docker'"
   listen: reload_sshd

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,7 +33,7 @@
     name: "{{ sshd_service }}"
     enabled: true
     state: started
-  when: sshd_manage_service and ansible_virtualization_type != 'docker'
+  when: "sshd_manage_service and ansible_virtualization_type|default(None) != 'docker'"
 
 - name: Register that this role has run
   set_fact: sshd_has_run=true


### PR DESCRIPTION
It looks like that `ansible_virtualization_type` is not defined by default in Ansible 2.5.1 when no virtualization is used. This resulted in this role failing due to an undefined variable.

This PR simply adds a jinja2 filter, so that `ansible_virtualization_type` defaults to `None` if not set.