### PR TITLE
Amazon var name should be sshd_defaults

### DIFF
--- a/vars/Amazon.yml
+++ b/vars/Amazon.yml
@@ -4,7 +4,7 @@ sshd_packages:
   - openssh
   - openssh-server
 sshd_sftp_server: /usr/libexec/openssh/sftp-server
-sshd:
+sshd_defaults:
   SyslogFacility: AUTHPRIV
   PermitRootLogin: forced-commands-only
   AuthorizedKeysFile: .ssh/authorized_keys


### PR DESCRIPTION
Otherwise `sshd_skip_defaults: true` will not skip default settings on Amazon Linux.
This seems a typo since any other Linux distro's var file uses `sshd_defaults` rather than `sshd`.
If the fix makes sense, I hope to see a patch release soon since it currently blocks me in my work 🙏 