### PR TITLE
Add CoreOS support

### DIFF
--- a/vars/Container Linux by CoreOS.yml
+++ b/vars/Container Linux by CoreOS.yml
@@ -1,0 +1,13 @@
+---
+# There is no package manager in CoreOS
+sshd_packages: []
+sshd_service: sshd
+sshd_sftp_server: internal-sftp
+sshd_defaults:
+  Subsystem: "sftp {{ sshd_sftp_server }}"
+  ClientAliveInterval: 180
+  UseDNS: no
+  UsePAM: yes
+  PrintLastLog: no
+  PrintMotd: no
+sshd_os_supported: yes


### PR DESCRIPTION
[CoreOS](https://coreos.com/why/) is a lightweight Linux operating system designed for clustered deployment of containers.

A few Ansible facts on CoreOS:
```
"ansible_distribution": "Container Linux by CoreOS"
"ansible_os_family": "Container Linux by CoreOS"
"ansible_distribution_major_version": "NA"
```

The original `sshd_config` for CoreOS:
```bash
core@ip-172-31-19-167 ~ $ sudo cat /etc/ssh/sshd_config 
# Use most defaults for sshd configuration.
Subsystem sftp internal-sftp
ClientAliveInterval 180
UseDNS no
UsePAM yes
PrintLastLog no # handled by PAM
PrintMotd no # handled by PAM
```

An official doc on how to customize SSH daemon on CoreOS:
https://coreos.com/os/docs/latest/customizing-sshd.html