### PR TITLE
expose sshd_config template backup option with sshd_backup variable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,8 @@ sshd_skip_defaults: false
 sshd_manage_service: true
 # If the below is false, don't reload the ssh daemon on change
 sshd_allow_reload: true
+# If the below is true, create a backup of the config file when the template is copied
+sshd_backup: false
 # Empty dicts to avoid errors
 sshd: {}
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,6 +25,7 @@
     owner: "{{ sshd_config_owner }}"
     group: "{{ sshd_config_group }}"
     mode: "{{ sshd_config_mode }}"
+    backup: "{{ sshd_backup }}"
     validate: "{{ sshd_binary }} -t -f %s"
   notify: reload_sshd
 


### PR DESCRIPTION
I would like to have a backup of the config files that are overwritten when the template is copied to a machine with an existing config file.  I propose to add a new variable, sshd_backup, which defaults to false.  If you set sshd_backup to true, it will activate the template module's backup option.