### PR TITLE
Make role work with chroot connections on EL 7.

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,5 +3,8 @@
   service:
     name: "{{ sshd_service }}"
     state: reloaded
-  when: "sshd_allow_reload and ansible_virtualization_type|default(None) != 'docker'"
+  when:
+    - sshd_allow_reload
+    - ansible_virtualization_type|default(None) != 'docker'
+    - ansible_connection != 'chroot'
   listen: reload_sshd

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -41,7 +41,18 @@
     name: "{{ sshd_service }}"
     enabled: true
     state: started
-  when: "sshd_manage_service and ansible_virtualization_type|default(None) != 'docker'"
+  when:
+    - sshd_manage_service
+    - ansible_virtualization_type|default(None) != 'docker'
+    - ansible_connection != 'chroot'
+
+# Due to ansible bug 21026, cannot use service module on RHEL 7
+- name: Enable service in chroot
+  command: systemctl enable {{ sshd_service }}
+  when:
+    - ansible_connection == 'chroot'
+    - ansible_os_family == 'RedHat'
+    - ansible_distribution_major_version|int >= 7
 
 - name: Register that this role has run
   set_fact: sshd_has_run=true


### PR DESCRIPTION
For chroot connection (e.g. when building images instead of working on
live hosts) one cannot restart services etc.

Also due to Ansible bug 21026 one must run systemctl instead of using
the service module, limiting support to EL 7 for the time being.