### PR TITLE
Add vars for openSUSE Leap 15 and CentOS 8

### DIFF
--- a/vars/RedHat_8.yml
+++ b/vars/RedHat_8.yml
@@ -1,0 +1,28 @@
+---
+__sshd_packages:
+  - openssh
+  - openssh-server
+__sshd_sftp_server: /usr/libexec/openssh/sftp-server
+__sshd_defaults:
+  HostKey:
+    - /etc/ssh/ssh_host_rsa_key
+    - /etc/ssh/ssh_host_ecdsa_key
+    - /etc/ssh/ssh_host_ed25519_key
+  SyslogFacility: AUTHPRIV
+  AuthorizedKeysFile: .ssh/authorized_keys
+  PasswordAuthentication: yes
+  ChallengeResponseAuthentication: no
+  GSSAPIAuthentication: yes
+  GSSAPICleanupCredentials: no
+# Note that UsePAM: no is not supported under RHEL/CentOS. See
+# https://github.com/willshersystems/ansible-sshd/pull/51#issuecomment-287333218
+  UsePAM: yes
+  X11Forwarding: yes
+  PrintMotd: no
+  AcceptEnv:
+    - LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES
+    - LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT
+    - LC_IDENTIFICATION LC_ALL LANGUAGE
+    - XMODIFIERS
+  Subsystem: "sftp {{ sshd_sftp_server }}"
+__sshd_os_supported: yes

--- a/vars/openSUSE Leap_15.yml
+++ b/vars/openSUSE Leap_15.yml
@@ -1,0 +1,14 @@
+---
+__sshd_packages:
+  - openssh
+__sshd_sftp_server: /usr/lib/ssh/sftp-server
+__sshd_defaults:
+  AuthorizedKeysFile: .ssh/authorized_keys
+  UsePAM: yes
+  X11Forwarding: yes
+  AcceptEnv:
+    - LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES
+    - LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT
+    - LC_IDENTIFICATION LC_ALL
+  Subsystem: "sftp {{ sshd_sftp_server }}"
+__sshd_os_supported: yes


### PR DESCRIPTION
Based on SLE11/SP2 and a fresh installation of openSUSE Leap 42.3

... rebased version of PR #70, including requested comments:

Suse (and also other distributions which setup PAM by default) usually disable PasswordAuthentication and rely only on the KeyboardInteractive method since users could otherwise still login despite their account being disabled by PAM-specific means. See also https://superuser.com/q/894608 for an explanation of the difference between Password and KeyboardInteractive authentication.

Whether or not the file can be versioned is up to you: of course it can (for example roll out the new version for `ansible_lsb.major_release|int >= 15 and <42`, just have to make sure that the lsb package is installed), but since your current configuration could allow users to bypass restrictions implemented via PAM I would not recommend it and instead put it in the release notes for the next version.