### PR TITLE
Fix variable loading.

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,7 +1,7 @@
 ---
 galaxy_info:
   author: Matt Willsher
-  description: OpenSSH SSH deamon configuration
+  description: OpenSSH SSH daemon configuration
   company: Willsher Systems
   license: LGPLv3
   min_ansible_version: 1.8

--- a/tasks/variables.yml
+++ b/tasks/variables.yml
@@ -2,12 +2,24 @@
 
 - name: Set OS dependent variables
   include_vars: "{{ item }}"
+  vars:
+    ansible_distribution_lts_offset: '{{
+      ansible_distribution_major_version|int % 2
+      if ansible_distribution == "Ubuntu"
+      else 0 }}'
+    ansible_distribution_lts_version: '{{
+      ansible_distribution_major_version|int -
+      ansible_distribution_lts_offset|int }}'
   with_first_found:
-   - "{{ ansible_distribution }}_{{ ansible_distribution_major_version }}.yml"
-   - "{{ ansible_distribution }}.yml"
-   - "{{ ansible_os_family }}_{{ ansible_distribution_major_version }}.yml"
-   - "{{ ansible_os_family }}.yml"
-   - default.yml
+    - files:
+        - "{{ ansible_distribution }}_{{ ansible_distribution_lts_version }}.yml"
+        - "{{ ansible_distribution }}.yml"
+        - "{{ ansible_os_family }}_{{ ansible_distribution_major_version }}.yml"
+        - "{{ ansible_os_family }}.yml"
+        - default.yml
+      paths:
+        - '{{ role_path }}/vars'
+        - '{{ playbook_dir }}/vars'
 
 - name: Override OS defaults
   block:


### PR DESCRIPTION
I discovered that [tasks/variables.yml](https://github.com/willshersystems/ansible-sshd/blob/master/tasks/variables.yml#L3) was searching in the `files` directory rather than the `vars` directory. (!!!)

This patch ensures that variable files are read from the `vars` directory of the current role or playbook.

It also adds compatibility for odd-numbered Ubuntu major releases.