### PR TITLE
Remove 'UsePrivilegeSeparation' from Fedora defaults

### DIFF
--- a/vars/Fedora.yml
+++ b/vars/Fedora.yml
@@ -16,7 +16,6 @@ __sshd_defaults:
   GSSAPICleanupCredentials: no
   UsePAM: yes
   X11Forwarding: yes
-  UsePrivilegeSeparation: sandbox
   AcceptEnv:
     - LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES
     - LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT


### PR DESCRIPTION
This option has been deprecated in OpenSSH for nearly two years, was the default for five years before that, and is not part of the current Fedora default configuration. It should not be included in sshd_config on Fedora systems.