### PR TITLE
OpenBSD and ansible_distribution_major_version

### DIFF
--- a/tasks/variables.yml
+++ b/tasks/variables.yml
@@ -16,15 +16,12 @@
         if ansible_distribution == "Ubuntu"
         else ansible_distribution_version
       }}
-    ansible_distribution_major_version: >-
-      {{
-        ansible_distribution_version if ansible_os_family == "OpenBSD"
-      }}
     params:
       files:
         - "{{ ansible_distribution }}_{{ ansible_distribution_lts_version }}.yml"
         - "{{ ansible_distribution }}.yml"
         - "{{ ansible_os_family }}_{{ ansible_distribution_major_version }}.yml"
+        - "{{ ansible_os_family }}_{{ ansible_distribution_version }}.yml"
         - "{{ ansible_os_family }}.yml"
         - default.yml
       paths:

--- a/tasks/variables.yml
+++ b/tasks/variables.yml
@@ -9,9 +9,17 @@
         if ansible_distribution == "Ubuntu"
         else 0
       }}
-    ansible_distribution_lts_version: '{{
-      ansible_distribution_major_version|int -
-      ansible_distribution_lts_offset|int }}'
+    ansible_distribution_lts_version: >-
+      {{
+        ansible_distribution_major_version|int -
+        ansible_distribution_lts_offset|int
+        if ansible_distribution == "Ubuntu"
+        else ansible_distribution_version
+      }}
+    ansible_distribution_major_version: >-
+      {{
+        ansible_distribution_version if ansible_os_family == "OpenBSD"
+      }}
     params:
       files:
         - "{{ ansible_distribution }}_{{ ansible_distribution_lts_version }}.yml"

--- a/tasks/variables.yml
+++ b/tasks/variables.yml
@@ -20,7 +20,6 @@
       files:
         - "{{ ansible_distribution }}_{{ ansible_distribution_lts_version }}.yml"
         - "{{ ansible_distribution }}.yml"
-        - "{{ ansible_os_family }}_{{ ansible_distribution_major_version }}.yml"
         - "{{ ansible_os_family }}_{{ ansible_distribution_version }}.yml"
         - "{{ ansible_os_family }}.yml"
         - default.yml


### PR DESCRIPTION
* OpenBSD no longer provides ansible fact "ansible_distribution_major_version" therefore set it to "ansible_distribution_version".

* ansible fact ansible_distribution_lts_version only makes sense on Ubuntu so set it only on Ubuntu -> otherwise "ansible_distribution_version"