### PR TITLE
Add Gentoo support (with secure sshd defaults)

### DIFF
--- a/vars/Gentoo.yml
+++ b/vars/Gentoo.yml
@@ -1,0 +1,37 @@
+---
+__sshd_packages:
+  - net-misc/openssh
+__sshd_config_owner: root
+__sshd_config_group: root
+__sshd_config_mode: "0600"
+__sshd_config_file: /etc/ssh/sshd_config
+__sshd_sftp_server: /usr/lib64/misc/sftp-server
+__sshd_binary: /usr/sbin/sshd
+__sshd_defaults:
+  Subsystem: "sftp {{ sshd_sftp_server }}"
+  # Replace tcp keepalive with unspoofable keepalive
+  TCPKeepAlive: no
+  ClientAliveInterval: 300
+  ClientAliveCountMax: 2
+  # Secure chipher and algorithm settings
+  HostKey:
+    - /etc/ssh/ssh_host_ed25519_key
+    - /etc/ssh/ssh_host_rsa_key
+  HostKeyAlgorithms: "ssh-ed25519,ssh-rsa,ssh-ed25519-cert-v01@openssh.com"
+  KexAlgorithms: "curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256"
+  Ciphers: "chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr"
+  MACs: "hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,umac-128@openssh.com"
+  AuthorizedKeysFile: .ssh/authorized_keys
+  # Security settings
+  PasswordAuthentication: no
+  ChallengeResponseAuthentication: no
+  PermitRootLogin: no
+  # Login settings
+  UsePAM: yes
+  PrintMotd: no
+  PrintLastLog: yes
+  # Disable most forwarding types for more security
+  AllowAgentForwarding: no
+  AllowTcpForwarding: no
+  AllowStreamLocalForwarding: no
+__sshd_os_supported: yes


### PR DESCRIPTION
This PR adds support for all Gentoo systems. Also includes secure defaults for the sshd configuration for gentoo.