### PR TITLE
End_host for unsupported hosts

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,8 +1,8 @@
 ---
 
 - name: OS is supported
-  assert:
-    that: __sshd_os_supported|bool
+  meta: end_host
+  when: not __sshd_os_supported|bool
 
 - name: Install ssh packages
   package:


### PR DESCRIPTION
This change will allow the play to continue without error if unsupported hosts are in the lists of targed host.
The play will continue with the supported hosts end the play for the ones which are not supported.

We had an issue where this role is used in a workflow against newly deployed nodes and obviously windows hosts will fail on this. This change allowed the workflow to continue.