### PR TITLE
Revert "End_host for unsupported hosts"

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,8 +1,8 @@
 ---
 
 - name: OS is supported
-  meta: end_host
-  when: not __sshd_os_supported|bool
+  assert:
+    that: __sshd_os_supported|bool
 
 - name: Install ssh packages
   package:


### PR DESCRIPTION
Reverts willshersystems/ansible-sshd#121

end_host is 2.8+ - this breaks runs on <2.7. Will save for a major release bump.