### PR TITLE
exit_host on ansible >= 2.8

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -3,13 +3,10 @@ name: Ansible Lint  # feel free to pick your own name
 on: [push, pull_request]
 
 jobs:
-  build:
-
+  test:
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v2
-
     - name: Lint Ansible Playbook
       uses: ansible/ansible-lint-action@master
       with:

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -1,0 +1,17 @@
+name: Ansible Lint  # feel free to pick your own name
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Lint Ansible Playbook
+      uses: ansible/ansible-lint-action@master
+      with:
+        targets: "tests/test.yml"
+        args: ""

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -3,7 +3,7 @@ name: Ansible Lint  # feel free to pick your own name
 on: [push, pull_request]
 
 jobs:
-  test:
+  test-ansible27:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -11,4 +11,39 @@ jobs:
       uses: ansible/ansible-lint-action@master
       with:
         targets: "tests/test.yml"
+        override-deps: |
+          ansible==2.7
+        args: ""
+  test-ansible28:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Lint Ansible Playbook
+      uses: ansible/ansible-lint-action@master
+      with:
+        targets: "tests/test.yml"
+        override-deps: |
+          ansible==2.8
+        args: ""
+  test-ansible29:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Lint Ansible Playbook
+      uses: ansible/ansible-lint-action@master
+      with:
+        targets: "tests/test.yml"
+        override-deps: |
+          ansible==2.9
+        args: ""
+  test-ansible210:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Lint Ansible Playbook
+      uses: ansible/ansible-lint-action@master
+      with:
+        targets: "tests/test.yml"
+        override-deps: |
+          ansible==2.10
         args: ""

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -3,6 +3,12 @@
 - name: OS is supported
   assert:
     that: __sshd_os_supported|bool
+  when: ansible_version.full is version_compare('2.8', '<')
+
+- name: OS is supported
+  meta: end_host
+  when: 
+    - not __sshd_os_supported|bool
 
 - name: Install ssh packages
   package:


### PR DESCRIPTION
I've added github action to lint the playbook but unfortunately it doesn't support testing with ansible 2.7 for now 