### PR TITLE
Minimum version is now Ansible 2.8

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -3,17 +3,6 @@ name: Ansible Lint  # feel free to pick your own name
 on: [push, pull_request]
 
 jobs:
-  test-ansible27:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Lint Ansible Playbook
-      uses: ansible/ansible-lint-action@master
-      with:
-        targets: "tests/test.yml"
-        override-deps: |
-          ansible==2.7
-        args: ""
   test-ansible28:
     runs-on: ubuntu-latest
     steps:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,10 +1,4 @@
 ---
-
-- name: OS is supported
-  assert:
-    that: __sshd_os_supported|bool
-  when: ansible_version.full is version_compare('2.8', '<')
-
 - name: OS is supported
   meta: end_host
   when: 


### PR DESCRIPTION
From #124 - ansible 2.7 isn't support by the current linter. Move to Ansible 2.8 support as a minimum.