### PR TITLE
Use ansible_distribution_major_version in variables

### DIFF
--- a/tasks/variables.yml
+++ b/tasks/variables.yml
@@ -19,7 +19,7 @@
       files:
         - "{{ ansible_distribution }}_{{ ansible_distribution_lts_version }}.yml"
         - "{{ ansible_distribution }}.yml"
-        - "{{ ansible_os_family }}_{{ ansible_distribution_version }}.yml"
+        - "{{ ansible_os_family }}_{{ ansible_distribution_major_version }}.yml"
         - "{{ ansible_os_family }}.yml"
         - default.yml
       paths:


### PR DESCRIPTION
In order to collect variables, it's worth using
ansible_distribution_major_version as ansible_distribution_version
changes behaviour between ansible releases, ie [1]

This causes CentOS jobs fail with 2.8.13, as
ansible_distribution_version there is '7.8' [2]

This is partially reverts #115

[1] https://github.com/ansible/ansible/issues/57463
[2] https://zuul.opendev.org/t/openstack/build/e5ae88e08ac546ccb0e7ab99f8f0a051/log/zuul-info/host-info.centos-7.yaml#141