### PR TITLE
Disable broken ansible-lint-actions

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -3,28 +3,28 @@ name: Ansible Lint  # feel free to pick your own name
 on: [push, pull_request]
 
 jobs:
-  test-ansible28:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Lint Ansible Playbook
-      uses: ansible/ansible-lint-action@master
-      with:
-        targets: "tests/test_*.yml"
-        override-deps: |
-          ansible==2.8
-        args: ""
-  test-ansible29:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Lint Ansible Playbook
-      uses: ansible/ansible-lint-action@master
-      with:
-        targets: "tests/test_*.yml"
-        override-deps: |
-          ansible==2.9
-        args: ""
+#  test-ansible28:
+#    runs-on: ubuntu-latest
+#    steps:
+#    - uses: actions/checkout@v2
+#    - name: Lint Ansible Playbook
+#      uses: ansible/ansible-lint-action@master
+#      with:
+#        targets: "tests/test_*.yml"
+#        override-deps: |
+#          ansible==2.8
+#        args: ""
+#  test-ansible29:
+#    runs-on: ubuntu-latest
+#    steps:
+#    - uses: actions/checkout@v2
+#    - name: Lint Ansible Playbook
+#      uses: ansible/ansible-lint-action@master
+#      with:
+#        targets: "tests/test_*.yml"
+#        override-deps: |
+#          ansible==2.9
+#        args: ""
   test-ansible210:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Ansible lint actions are currently broken for overrides of the Ansible version.  Disable until fixed.