### PR TITLE
Support /etc/sysconfig/sshd to override crypto policies and handle more advanced use cases

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,6 +23,19 @@ sshd_allow_reload: true
 # If the below is true, create a backup of the config file when the template is copied
 sshd_backup: true
 
+# If the below is true, also install the sysconfig file with the below options
+# (useful only on Fedora and RHEL)
+sshd_sysconfig: false
+
+# If the below is true the role will override also crypto policy configuration
+sshd_sysconfig_override_crypto_policy: false
+
+# If the below is set to non-zero value, the OpenSSL random generator is
+# reseeded with the given amount of random bytes (from getrandom(2)
+# with GRND_RANDOM or /dev/random). Minimum is 14 bytes when enabled.
+# This is not recommended to enable if you do not have hadware random generator
+sshd_sysconfig_use_strong_rng: 0
+
 # Empty dicts to avoid errors
 sshd: {}
 
@@ -43,3 +56,6 @@ __sshd_service: sshd
 __sshd_sftp_server: /usr/lib/openssh/sftp-server
 __sshd_defaults: {}
 __sshd_os_supported: no
+__sshd_sysconfig: false
+__sshd_sysconfig_supports_crypto_policy: false
+__sshd_sysconfig_supports_use_strong_rng: false

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -20,6 +20,18 @@
     backup: "{{ sshd_backup }}"
   notify: reload_sshd
 
+- name: Sysconfig configuration
+  template:
+    src: sysconfig.j2
+    dest: "/etc/sysconfig/sshd"
+    owner: "root"
+    group: "root"
+    mode: "600"
+    backup: "{{ sshd_backup }}"
+  when:
+    - sshd_sysconfig|bool
+  notify: reload_sshd
+
 - name: Install systemd service files
   block:
     - name: Install service unit file

--- a/tasks/variables.yml
+++ b/tasks/variables.yml
@@ -60,3 +60,7 @@
       set_fact:
         sshd_sftp_server: "{{ __sshd_sftp_server }}"
       when: sshd_sftp_server is not defined
+    - name: Define sshd_sysconfig
+      set_fact:
+        sshd_sysconfig: "{{ __sshd_sysconfig }}"
+      when: sshd_sysconfig is not defined

--- a/templates/sysconfig.j2
+++ b/templates/sysconfig.j2
@@ -1,0 +1,10 @@
+# {{ ansible_managed }}
+{% if __sshd_sysconfig_supports_crypto_policy %}
+{%   if sshd_sysconfig_override_crypto_policy == true %}
+CRYPTO_POLICY=
+{%   endif %}
+{% endif %}
+
+{% if __sshd_sysconfig_supports_use_strong_rng %}
+SSH_USE_STRONG_RNG={{ sshd_sysconfig_use_strong_rng }}
+{% endif %}

--- a/tests/test_sysconfig.yml
+++ b/tests/test_sysconfig.yml
@@ -1,0 +1,30 @@
+---
+- hosts: all
+  become: true
+  tasks:
+  - name: Configure sshd
+    include_role:
+      name: ansible-sshd
+    vars:
+      sshd_sysconfig: true
+      sshd_sysconfig_override_crypto_policy: true
+      sshd_sysconfig_use_strong_rng: 32
+
+  - name: Verify the options are correctly set
+    block:
+      - meta: flush_handlers
+
+      - name: Print current configuration file
+        command: cat /etc/sysconfig/sshd
+        register: config
+
+      - name: Check the options are in configuration file
+        assert:
+          that:
+            - "'CRYPTO_POLICY=' in config.stdout_lines"
+            - "'SSH_USE_STRONG_RNG=32' in config.stdout_lines"
+            # these are string variants in default configuration file
+            - "'# CRYPTO_POLICY=' not in config.stdout_lines"
+            - "'SSH_USE_STRONG_RNG=0' not in config.stdout_lines"
+            - "'# SSH_USE_STRONG_RNG=1' not in config.stdout_lines"
+    tags: tests::verify

--- a/vars/Fedora_31.yml
+++ b/vars/Fedora_31.yml
@@ -23,3 +23,4 @@ __sshd_defaults:
     - XMODIFIERS
   Subsystem: "sftp {{ sshd_sftp_server }}"
 __sshd_os_supported: yes
+__sshd_sysconfig_supports_crypto_policy: true

--- a/vars/RedHat_6.yml
+++ b/vars/RedHat_6.yml
@@ -19,3 +19,4 @@ __sshd_defaults:
   X11Forwarding: yes
   Subsystem: "sftp {{ sshd_sftp_server }}"
 __sshd_os_supported: yes
+__sshd_sysconfig_supports_use_strong_rng: true

--- a/vars/RedHat_7.yml
+++ b/vars/RedHat_7.yml
@@ -26,3 +26,4 @@ __sshd_defaults:
     - XMODIFIERS
   Subsystem: "sftp {{ sshd_sftp_server }}"
 __sshd_os_supported: yes
+__sshd_sysconfig_supports_use_strong_rng: true

--- a/vars/RedHat_8.yml
+++ b/vars/RedHat_8.yml
@@ -26,3 +26,5 @@ __sshd_defaults:
     - XMODIFIERS
   Subsystem: "sftp {{ sshd_sftp_server }}"
 __sshd_os_supported: yes
+__sshd_sysconfig_supports_use_strong_rng: true
+__sshd_sysconfig_supports_crypto_policy: true


### PR DESCRIPTION
This should solve #141. Test playbook is written too, but it does not make much sense to run in on Ubuntu as it should not do anything there.

On the other hand, the file is just list of environment variables  so it should not hurt if unsupported values are written in there. I would be glad for review/comments/suggestions/testing.