### PR TITLE
Implement more natural match blocks and test them

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,3 +47,15 @@ script:
     ANSIBLE_FORCE_COLOR=1 ansible-playbook -i tests/inventory tests/test_alternative_file.yml --connection=local --become -v
     && (echo 'Alternative configuration file test: pass' && exit 0)
     || (echo 'Alternative configuration file test: fail' && exit 1)
+
+  # Test 6: Test match blocks generators
+  - >
+    ANSIBLE_FORCE_COLOR=1 ansible-playbook -i tests/inventory tests/test_match.yml --connection=local --become -v
+    && (echo 'Match blocks test: pass' && exit 0)
+    || (echo 'Match blocks test: fail' && exit 1)
+
+  # Test 7: Test match blocks generators with iteration
+  - >
+    ANSIBLE_FORCE_COLOR=1 ansible-playbook -i tests/inventory tests/test_match_iterate.yml --connection=local --become -v
+    && (echo 'Match blocks with iteration test: pass' && exit 0)
+    || (echo 'Match blocks with iteration test: fail' && exit 1)

--- a/templates/sshd_config.j2
+++ b/templates/sshd_config.j2
@@ -91,6 +91,15 @@ Match {{ match["Condition"] }}
 {%     endfor %}
 {%   endif %}
 {% endmacro %}
+{% macro match_iterate_block(match_list) %}
+{%   if match_list | type_debug == "list" %}
+{%     for match in match_list %}
+{{       match_block(match) -}}
+{%     endfor %}
+{%   else %}
+{{     match_block(match_list) -}}
+{%   endif %}
+{% endmacro %}
 {{ body_option("Port",sshd_Port) -}}
 {{ body_option("AddressFamily",sshd_AddressFamily) -}}
 {{ body_option("ListenAddress",sshd_ListenAddress) -}}
@@ -199,10 +208,10 @@ Match {{ match["Condition"] }}
 {{ body_option("X11UseLocalhost",sshd_X11UseLocalhost) -}}
 {{ body_option("XAuthLocation",sshd_XAuthLocation) -}}
 {% if sshd['Match'] is defined %}
-{{ match_block(sshd['Match']) -}}
+{{   match_iterate_block(sshd['Match']) -}}
 {% endif %}
 {% if sshd_match is defined %}
-{{ match_block(sshd_match) -}}
+{{   match_iterate_block(sshd_match) -}}
 {% endif %}
 {% if sshd_match_1 is defined %}
 {{ match_block(sshd_match_1) -}}

--- a/tests/test_match.yml
+++ b/tests/test_match.yml
@@ -1,0 +1,73 @@
+---
+- hosts: all
+  become: true
+  tasks:
+  - name: Configure sshd
+    include_role:
+      name: ansible-sshd
+    vars:
+      sshd:
+        Match:
+        - Condition: "User xusers"
+          X11Forwarding: yes
+          Banner: /tmp/xusers-banner
+      sshd_match:
+        - Condition: "User bot"
+          AllowTcpForwarding: no
+          Banner: /tmp/bot-banner
+      sshd_match_1:
+        - Condition: "User sftponly"
+          ForceCommand: "internal-sftp"
+          ChrootDirectory: "/var/uploads/"
+      sshd_match_2:
+        - Condition: "User root"
+          PasswordAuthentication: no
+          PermitTunnel: yes
+
+
+  - name: Verify the options are correctly set
+    block:
+      - meta: flush_handlers
+
+      - name: List effective configuration using sshd -T for xusers
+        command: sshd -T -C user=xusers
+        register: xusers_effective
+
+      - name: List effective configuration using sshd -T for bot
+        command: sshd -T -C user=bot
+        register: bot_effective
+
+      - name: List effective configuration using sshd -T for sftponly
+        command: sshd -T -C user=sftponly
+        register: sftponly_effective
+
+      - name: List effective configuration using sshd -T for root
+        command: sshd -T -C user=root
+        register: root_effective
+
+      - name: Print current configuration file
+        command: cat /etc/ssh/sshd_config
+        register: config
+
+      - name: Check the options are effective
+        # note, the options are in lower-case here
+        assert:
+          that:
+            - "'x11forwarding yes' in xusers_effective.stdout"
+            - "'banner /tmp/xusers-banner' in xusers_effective.stdout"
+            - "'allowtcpforwarding no' in bot_effective.stdout"
+            - "'banner /tmp/bot-banner' in bot_effective.stdout"
+            - "'forcecommand internal-sftp' in sftponly_effective.stdout"
+            - "'chrootdirectory /var/uploads/' in sftponly_effective.stdout"
+            - "'passwordauthentication no' in root_effective.stdout"
+            - "'permittunnel yes' in root_effective.stdout"
+
+      - name: Check the options are in configuration file
+        assert:
+          that:
+            - "'Match User xusers' in config.stdout"
+            - "'Match User bot' in config.stdout"
+            - "'Match User sftponly' in config.stdout"
+            - "'Match User root' in config.stdout"
+    tags: tests::verify
+

--- a/tests/test_match_iterate.yml
+++ b/tests/test_match_iterate.yml
@@ -1,0 +1,71 @@
+---
+- hosts: all
+  become: true
+  tasks:
+  - name: Configure sshd
+    include_role:
+      name: ansible-sshd
+    vars:
+      sshd:
+        Match:
+        - Condition: "User xusers"
+          X11Forwarding: yes
+          Banner: /tmp/xusers-banner
+        - Condition: "User bot"
+          AllowTcpForwarding: no
+          Banner: /tmp/bot-banner
+      sshd_match:
+        - Condition: "User sftponly"
+          ForceCommand: "internal-sftp"
+          ChrootDirectory: "/var/uploads/"
+        - Condition: "User root"
+          PasswordAuthentication: no
+          PermitTunnel: yes
+
+
+  - name: Verify the options are correctly set
+    block:
+      - meta: flush_handlers
+
+      - name: List effective configuration using sshd -T for xusers
+        command: sshd -T -C user=xusers
+        register: xusers_effective
+
+      - name: List effective configuration using sshd -T for bot
+        command: sshd -T -C user=bot
+        register: bot_effective
+
+      - name: List effective configuration using sshd -T for sftponly
+        command: sshd -T -C user=sftponly
+        register: sftponly_effective
+
+      - name: List effective configuration using sshd -T for root
+        command: sshd -T -C user=root
+        register: root_effective
+
+      - name: Print current configuration file
+        command: cat /etc/ssh/sshd_config
+        register: config
+
+      - name: Check the options are effective
+        # note, the options are in lower-case here
+        assert:
+          that:
+            - "'x11forwarding yes' in xusers_effective.stdout"
+            - "'banner /tmp/xusers-banner' in xusers_effective.stdout"
+            - "'allowtcpforwarding no' in bot_effective.stdout"
+            - "'banner /tmp/bot-banner' in bot_effective.stdout"
+            - "'forcecommand internal-sftp' in sftponly_effective.stdout"
+            - "'chrootdirectory /var/uploads/' in sftponly_effective.stdout"
+            - "'passwordauthentication no' in root_effective.stdout"
+            - "'permittunnel yes' in root_effective.stdout"
+
+      - name: Check the options are in configuration file
+        assert:
+          that:
+            - "'Match User xusers' in config.stdout"
+            - "'Match User bot' in config.stdout"
+            - "'Match User sftponly' in config.stdout"
+            - "'Match User root' in config.stdout"
+    tags: tests::verify
+


### PR DESCRIPTION
One of the things that I noticed cumbersome in this role was the definition of Match blocks, which was supported in different ways, but limited to 11 blocks or so with `sshd['Match']`, `sshd_match` and `sshd_match_[1-9]`.

This implements alternative way describing match blocks as a list in `sshd['Match']` or `sshd_match`, keeping the old semantics unchanged for backward compatibility.