### PR TITLE
feat: add support for non-exclusive configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,12 @@ Using these variables, you can use your own custom templates. With the above
 default templates, the name of the installed ssh service will be provided by
 the `sshd_service` variable.
 
+* `sshd_exclusive_configuration`
+
+If set to *false*, do not manage SSH configuration exclusively.
+This allows SSH configuration modifications from other tasks or roles (e.g sftp role, ...) while preserving idempotency.
+Defaults to *true*.
+
 * `sshd`
 
 A dict containing configuration.  e.g.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,10 @@
 # Set to false to disable this role completely
 sshd_enable: true
 
+# If set to *false*, do not manage SSH configuration exclusively.
+# This allows SSH configuration modifications from other tasks or roles (e.g sftp role, ...) while preserving idempotency.
+sshd_exclusive_configuration: true
+
 # Don't apply OS defaults when set to true
 sshd_skip_defaults: false
 

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -95,6 +95,47 @@
           {% endif %}
         backup: "{{ sshd_backup }}"
       notify: reload_sshd
+      when: sshd_exclusive_configuration | bool
+
+    - name: Non-exclusive configuration
+      when: not sshd_exclusive_configuration | bool
+      vars:
+        marker_begin: BEGIN
+        marker: "# {mark} ANSIBLE SSH MANAGED CONFIGURATION"
+      block:
+        - name: Check if configuration block is present
+          lineinfile:
+            path: "{{ sshd_config_file }}"
+            line: "{{ marker.format(mark=marker_begin) }}"
+            state: present
+          check_mode: true
+          register: configuration_block_presence
+
+        - name: Remove default configuration
+          file:
+            path: "{{ sshd_config_file }}"
+            state: absent
+          when: configuration_block_presence is changed
+
+        - name: Copy configuration
+          blockinfile:
+            block: "{{ lookup('template', 'sshd_config.j2') }}"
+            dest: "{{ sshd_config_file }}"
+            create: true
+            owner: "{{ sshd_config_owner }}"
+            group: "{{ sshd_config_group }}"
+            mode: "{{ sshd_config_mode }}"
+            marker_begin: "{{ marker_begin }}"
+            marker: "{{ marker }}"
+            validate: >-
+              {% if sshd_test_hostkey is defined and sshd_test_hostkey.path is defined %}
+                {{ sshd_binary }} -t -f %s -h {{ sshd_test_hostkey.path }}/rsa_key
+              {% else %}
+                {{ sshd_binary }} -t -f %s
+              {% endif %}
+            backup: "{{ sshd_backup }}"
+          notify: reload_sshd
+
   rescue:
     - name: re-raise the error
       fail:


### PR DESCRIPTION
This is an updated version of https://github.com/willshersystems/ansible-sshd/pull/71.
The idea is still the same: provide the ability configure SSH in a non exclusive manner.

The main use case is for other playbooks, tasks or roles to update SSH configuration while preserving idempotency:
I have a playbook `common.yml` that configures server basics that uses this role to configure SSH with default values.
When I later add another playbook for a specific software for instance that requires some specific SSH configuration, I want this specific configuration to be part of this software playbook to ensure the playbook contains everything that software requires (kind of SOLID principles applied to playbooks). But I don't want further `common.yml` runs to overwrite it. 

This provides kind of the same functionality as the `sshd_config` [Include](https://bugzilla.mindrot.org/show_bug.cgi?id=2468) that has been added to  OpenSSH 8.1 for older versions.