### PR TITLE
[FreeBSD] Add Subsystem to _sshd_defaults

### DIFF
--- a/vars/FreeBSD.yml
+++ b/vars/FreeBSD.yml
@@ -2,4 +2,6 @@
 sshd_config_group: wheel
 sshd_config_mode: "0644"
 sshd_sftp_server: /usr/libexec/sftp-server
+__sshd_defaults:
+  Subsystem: "sftp {{ sshd_sftp_server }}"
 __sshd_os_supported: yes


### PR DESCRIPTION
The Subsystem entry was missing for FreeBSD OS, noticed this while provisioning a TrueNAS box. After the first provision ansible was unable to upload any files due to that missing setting. Tested this change by adjusting the role locally and rerunning it with a clean sshd_config on the remote side, worked fine.