### PR TITLE
use state: absent instead of state: missing

### DIFF
--- a/tests/tests_hostkeys_missing.yml
+++ b/tests/tests_hostkeys_missing.yml
@@ -40,7 +40,7 @@
   - name: Make sure the key was not created
     file:
       path: /tmp/missing_ssh_host_rsa_key
-      state: missing
+      state: absent
     register: key
     failed_when: key.changed
     tags: tests::verify


### PR DESCRIPTION
found this when running the role on rhel7/ansible 2.8/jinja 2.7
@Jakuje 