### PR TITLE
Drop support for Ansible 2.8 by bumping the Ansible version to 2.9

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -13,7 +13,7 @@ jobs:
   #       with:
   #         targets: "tests/test_*.yml"
   #         override-deps: |
-  #           ansible==2.8
+  #           ansible==2.9
   #         args: ""
   # test-ansible29:
   #   runs-on: ubuntu-latest

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: OpenSSH SSH daemon configuration
   company: Willsher Systems
   license: LGPLv3
-  min_ansible_version: 2.8
+  min_ansible_version: 2.9
   platforms:
     - name: Debian
       versions:


### PR DESCRIPTION
Bug 1989197 - drop support for Ansible 2.8
https://bugzilla.redhat.com/show_bug.cgi?id=1989197
