### PR TITLE
Add CentOS 6 to CI

### DIFF
--- a/.github/workflows/ansible-centos6.yml
+++ b/.github/workflows/ansible-centos6.yml
@@ -1,0 +1,19 @@
+name: Run tests on CentOS 6
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    # Workaround missing support for end_host in old ansible
+    - run: "sed -i -e 's/meta: end_host/assert:\\n    that: __sshd_os_supported|bool/' tasks/install.yml"
+
+    - name: ansible check with centos:6
+      uses: roles-ansible/check-ansible-centos-centos6-action@master
+      with:
+        group: local
+        hosts: localhost
+        targets: "tests/*.yml"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -126,7 +126,7 @@
         group: "{{ sshd_config_group }}"
         mode: "{{ sshd_config_mode }}"
         block: |
-          Match all
+          {{ __sshd_compat_match_all }}
           {{ lookup('template', 'sshd_config_snippet.j2') }}
         create: yes
         marker: "# {mark} sshd system role managed block: namespace {{ sshd_config_namespace }}"

--- a/tests/tests_config_namespace.yml
+++ b/tests/tests_config_namespace.yml
@@ -60,17 +60,31 @@
           command: sshd -T -Cuser=nobody,host=example.com,addr=127.0.0.2
           register: nonmatching
 
+        - name: Check content of configuration file (blocks)
+          assert:
+            that:
+              - "config.content | b64decode | regex_search('Match all\\s*AcceptEnv EDITOR')"
+              - "config.content | b64decode | regex_search('Match all\\s*AcceptEnv LS_COLORS')"
+          when:
+            - ansible_facts['os_family'] != 'RedHat' or ansible_facts['distribution_major_version'] != '6'
+
+        - name: Check content of configuration file (blocks for RHEL 6)
+          assert:
+            that:
+              - "config.content | b64decode | regex_search('Match address *\\s*AcceptEnv EDITOR')"
+              - "config.content | b64decode | regex_search('Match address *\\s*AcceptEnv LS_COLORS')"
+          when:
+            - ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution_major_version'] == '6'
+
         - name: Check content of configuration file
           assert:
             that:
               - "'AcceptEnv EDITOR' in config.content | b64decode"
-              - "config.content | b64decode | regex_search('Match all\\s*AcceptEnv EDITOR')"
               - "'PasswordAuthentication yes' in config.content | b64decode"
               - "'Match user root' in config.content | b64decode"
               - "'AllowAgentForwarding no' in config.content | b64decode"
               - "config.content | b64decode | regex_search('Match user root\\s*AllowAgentForwarding no')"
               - "'AcceptEnv LS_COLORS' in config.content | b64decode"
-              - "config.content | b64decode | regex_search('Match all\\s*AcceptEnv LS_COLORS')"
               - "'PasswordAuthentication no' in config.content | b64decode"
               - "'Match Address 127.0.0.1' in config.content | b64decode"
               - "'AllowTcpForwarding no' in config.content | b64decode"

--- a/tests/tests_config_namespace.yml
+++ b/tests/tests_config_namespace.yml
@@ -16,8 +16,8 @@
         sshd_config_file: /etc/ssh/sshd_config
         sshd_config_namespace: nm1
         sshd:
-          AcceptEnv: EDITOR
           PasswordAuthentication: yes
+          PermitRootLogin: yes
           Match:
             Condition: user root
             AllowAgentForwarding: no
@@ -29,8 +29,8 @@
         sshd_config_file: /etc/ssh/sshd_config
         sshd_config_namespace: nm2
         sshd:
-          AcceptEnv: LS_COLORS
           PasswordAuthentication: no
+          PermitRootLogin: no
           Match:
             Condition: Address 127.0.0.1
             AllowTcpForwarding: no
@@ -63,28 +63,28 @@
         - name: Check content of configuration file (blocks)
           assert:
             that:
-              - "config.content | b64decode | regex_search('Match all\\s*AcceptEnv EDITOR')"
-              - "config.content | b64decode | regex_search('Match all\\s*AcceptEnv LS_COLORS')"
+              - "config.content | b64decode | regex_search('Match all\\s*PasswordAuthentication yes')"
+              - "config.content | b64decode | regex_search('Match all\\s*PasswordAuthentication no')"
           when:
             - ansible_facts['os_family'] != 'RedHat' or ansible_facts['distribution_major_version'] != '6'
 
         - name: Check content of configuration file (blocks for RHEL 6)
           assert:
             that:
-              - "config.content | b64decode | regex_search('Match address *\\s*AcceptEnv EDITOR')"
-              - "config.content | b64decode | regex_search('Match address *\\s*AcceptEnv LS_COLORS')"
+              - "config.content | b64decode | regex_search('Match address \\*\\s*PasswordAuthentication yes')"
+              - "config.content | b64decode | regex_search('Match address \\*\\s*PasswordAuthentication no')"
           when:
             - ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution_major_version'] == '6'
 
         - name: Check content of configuration file
           assert:
             that:
-              - "'AcceptEnv EDITOR' in config.content | b64decode"
+              - "'PermitRootLogin yes' in config.content | b64decode"
               - "'PasswordAuthentication yes' in config.content | b64decode"
               - "'Match user root' in config.content | b64decode"
               - "'AllowAgentForwarding no' in config.content | b64decode"
               - "config.content | b64decode | regex_search('Match user root\\s*AllowAgentForwarding no')"
-              - "'AcceptEnv LS_COLORS' in config.content | b64decode"
+              - "'PermitRootLogin no' in config.content | b64decode"
               - "'PasswordAuthentication no' in config.content | b64decode"
               - "'Match Address 127.0.0.1' in config.content | b64decode"
               - "'AllowTcpForwarding no' in config.content | b64decode"
@@ -94,9 +94,8 @@
           # note, the options are in lower-case here
           assert:
             that:
-              - "'acceptenv EDITOR' in runtime.stdout"
+              - "'permitrootlogin yes' in runtime.stdout"
               - "'allowagentforwarding no' in runtime.stdout"
-              - "'acceptenv LS_COLORS' in runtime.stdout"
               - "'allowtcpforwarding no' in runtime.stdout"
               - "'passwordauthentication yes' in runtime.stdout"
 
@@ -104,9 +103,8 @@
           # note, the options are in lower-case here
           assert:
             that:
-              - "'acceptenv EDITOR' in nonmatching.stdout"
+              - "'permitrootlogin yes' in runtime.stdout"
               - "'allowAgentforwarding no' not in nonmatching.stdout"
-              - "'acceptenv LS_COLORS' in nonmatching.stdout"
               - "'allowtcpforwarding no' not in nonmatching.stdout"
               - "'passwordauthentication yes' in nonmatching.stdout"
       tags: tests::verify

--- a/tests/tests_hostkeys_missing.yml
+++ b/tests/tests_hostkeys_missing.yml
@@ -52,6 +52,8 @@
       register: result
       failed_when: result.changed
       tags: tests::verify
+      when:
+        - not (ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution_major_version'] == '6')
 
     - name: "Restore configuration files"
       include_tasks: tasks/restore.yml

--- a/tests/tests_hostkeys_missing.yml
+++ b/tests/tests_hostkeys_missing.yml
@@ -34,7 +34,7 @@
             msg: "Role has not failed when it should have"
           when:
             - ansible_facts['os_family'] != 'Debian'
-            - not (ansible_facts['distribution'] == 'RedHat' and ansible_facts['distribution_major_version'] == '6')
+            - not (ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution_major_version'] == '6')
       tags: tests::verify
 
     - name: Make sure the key was not created

--- a/tests/tests_hostkeys_missing.yml
+++ b/tests/tests_hostkeys_missing.yml
@@ -32,9 +32,9 @@
               - ansible_failed_result.msg != 'UNREACH'
               - not role_result.changed
             msg: "Role has not failed when it should have"
-          when:
-            - ansible_facts['os_family'] != 'Debian'
-            - not (ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution_major_version'] == '6')
+      when:
+        - ansible_facts['os_family'] != 'Debian'
+        - not (ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution_major_version'] == '6')
       tags: tests::verify
 
     - name: Make sure the key was not created

--- a/tests/tests_os_defaults.yml
+++ b/tests/tests_os_defaults.yml
@@ -34,7 +34,8 @@
         that:
           - runtime_before.stdout == runtime_after.stdout
       when:
-        - not (ansible_facts['distribution'] == 'RedHat' and ansible_facts['distribution_major_version'] == '6')
+        # RHEL6/CentOS6 images have modified sshd_config, different from what is in rpm package
+        - not (ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution_major_version'] == '6')
 
     - name: Restore configuration files
       include_tasks: tasks/restore.yml

--- a/tests/tests_set_uncommon.yml
+++ b/tests/tests_set_uncommon.yml
@@ -48,6 +48,8 @@
               - ansible_failed_result.msg != 'UNREACH'
               - not role_result.changed
             msg: "Role has not failed when it should have"
+      when:
+        - not (ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution_major_version'] == '6')
 
     - name: Make sure service is still running
       service:
@@ -56,6 +58,8 @@
       register: result
       failed_when: result.changed
       tags: tests::verify
+      when:
+        - not (ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution_major_version'] == '6')
 
     - name: "Restore configuration files"
       include_tasks: tasks/restore.yml

--- a/vars/RedHat_6.yml
+++ b/vars/RedHat_6.yml
@@ -22,3 +22,4 @@ __sshd_defaults:
   Subsystem: "sftp {{ sshd_sftp_server }}"
 __sshd_os_supported: yes
 __sshd_sysconfig_supports_use_strong_rng: true
+__sshd_compat_match_all: Match address *

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -5,3 +5,5 @@ __sshd_config_mode: "0600"
 __sshd_hostkey_owner: "root"
 __sshd_hostkey_group: "root"
 __sshd_hostkey_mode: "0600"
+# The OpenSSH 5.3 in RHEL6 does not support "Match all" so we need a workaround
+__sshd_compat_match_all: Match all


### PR DESCRIPTION
The RHEL6/CentOS 6 has a lot of issues, but we still need to make sure it works at least with best effort.

This PR removes one incompatibility which was introduced with the namespaces, adjusts testsuite to work there and adds Github Action for CentOS6 (with a tweak removing the `end_host` part, which is not compatible with Ansible version available there).