### PR TITLE
Add Debian 11 (bullseye) support

### DIFF
--- a/.github/workflows/ansible-debian-bullseye.yml
+++ b/.github/workflows/ansible-debian-bullseye.yml
@@ -1,0 +1,18 @@
+name: Run tests on Debian bullseye (11)
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      # Important: This sets up your GITHUB_WORKSPACE environment variable
+      - name: checkout PR
+        uses: actions/checkout@v2
+
+      - name: ansible check with debian:bullseye (11)
+        uses: roles-ansible/check-ansible-debian-bullseye-action@master
+        with:
+          group: local
+          hosts: localhost
+          targets: "tests/*.yml"

--- a/.github/workflows/ansible-debian-bullseye.yml
+++ b/.github/workflows/ansible-debian-bullseye.yml
@@ -12,6 +12,7 @@ jobs:
 
       - name: ansible check with debian:bullseye (11)
         uses: roles-ansible/check-ansible-debian-bullseye-action@main
+        with:
           group: local
           hosts: localhost
           targets: "tests/*.yml"

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Requirements
 Tested on:
 
 * Ubuntu precise, trusty, xenial, bionic, focal
-* Debian wheezy, jessie, stretch, buster
+* Debian wheezy, jessie, stretch, buster, bullseye
 * FreeBSD 10.1
 * EL 6, 7, 8, 9 derived distributions
 * Fedora 31, 32, 33, 34

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,6 +12,7 @@ galaxy_info:
         - jessie
         - stretch
         - buster
+        - bullseye
     - name: Ubuntu
       versions:
         - precise

--- a/vars/Debian_11.yml
+++ b/vars/Debian_11.yml
@@ -1,0 +1,15 @@
+---
+sshd_service: ssh
+sshd_packages:
+  - openssh-server
+  - openssh-sftp-server
+__sshd_config_mode: "0644"
+__sshd_defaults:
+  ChallengeResponseAuthentication: no
+  X11Forwarding: yes
+  PrintMotd: no
+  AcceptEnv: LANG LC_*
+  Subsystem: "sftp {{ sshd_sftp_server }}"
+  UsePAM: yes
+__sshd_os_supported: yes
+__sshd_runtime_directory: /run/sshd


### PR DESCRIPTION
This PR adds bullseye support to the role.
The workflow fails at the moment because there is no `roles-ansible/check-ansible-debian-bullseye-action` repo yet.
Debian 11 will be released at the 14. Aug. So it would be nice to have this role ready till saturday.