### PR TITLE
Make the role FIPS-aware

### DIFF
--- a/.github/workflows/ansible-centos6.yml
+++ b/.github/workflows/ansible-centos6.yml
@@ -16,4 +16,4 @@ jobs:
       with:
         group: local
         hosts: localhost
-        targets: "tests/*.yml"
+        targets: "tests/tests_*.yml"

--- a/.github/workflows/ansible-centos7.yml
+++ b/.github/workflows/ansible-centos7.yml
@@ -14,4 +14,4 @@ jobs:
         with:
           group: local
           hosts: localhost
-          targets: "tests/*.yml"
+          targets: "tests/tests_*.yml"

--- a/.github/workflows/ansible-centos8.yml
+++ b/.github/workflows/ansible-centos8.yml
@@ -14,4 +14,4 @@ jobs:
         with:
           group: local
           hosts: localhost
-          targets: "tests/*.yml"
+          targets: "tests/tests_*.yml"

--- a/.github/workflows/ansible-debian-bullseye.yml
+++ b/.github/workflows/ansible-debian-bullseye.yml
@@ -15,4 +15,4 @@ jobs:
         with:
           group: local
           hosts: localhost
-          targets: "tests/*.yml"
+          targets: "tests/tests_*.yml"

--- a/.github/workflows/ansible-debian-buster.yml
+++ b/.github/workflows/ansible-debian-buster.yml
@@ -15,4 +15,4 @@ jobs:
         with:
           group: local
           hosts: localhost
-          targets: "tests/*.yml"
+          targets: "tests/tests_*.yml"

--- a/.github/workflows/ansible-debian-stretch.yml
+++ b/.github/workflows/ansible-debian-stretch.yml
@@ -15,4 +15,4 @@ jobs:
         with:
           group: local
           hosts: localhost
-          targets: "tests/*.yml"
+          targets: "tests/tests_*.yml"

--- a/.github/workflows/ansible-debian.yml
+++ b/.github/workflows/ansible-debian.yml
@@ -15,4 +15,4 @@ jobs:
         with:
           group: local
           hosts: localhost
-          targets: "tests/*.yml"
+          targets: "tests/tests_*.yml"

--- a/.github/workflows/ansible-fedora.yml
+++ b/.github/workflows/ansible-fedora.yml
@@ -15,4 +15,4 @@ jobs:
         with:
           group: local
           hosts: localhost
-          targets: "tests/*.yml"
+          targets: "tests/tests_*.yml"

--- a/.github/workflows/ansible-ubuntu.yml
+++ b/.github/workflows/ansible-ubuntu.yml
@@ -15,4 +15,4 @@ jobs:
         with:
           group: local
           hosts: localhost
-          targets: "tests/*.yml"
+          targets: "tests/tests_*.yml"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -74,8 +74,6 @@ __sshd_defaults: {}
 __sshd_os_supported: no
 __sshd_sysconfig_supports_crypto_policy: false
 __sshd_sysconfig_supports_use_strong_rng: false
-# The hostkeys not supported in FIPS mode, if applicable
-__sshd_hostkeys_nofips: []
 
 __sshd_runtime_directory: false
 __sshd_runtime_directory_mode: "0755"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -74,7 +74,8 @@ __sshd_defaults: {}
 __sshd_os_supported: no
 __sshd_sysconfig_supports_crypto_policy: false
 __sshd_sysconfig_supports_use_strong_rng: false
-
+# The hostkeys not supported in FIPS mode, if applicable
+__sshd_hostkeys_nofips: []
 
 __sshd_runtime_directory: false
 __sshd_runtime_directory_mode: "0755"

--- a/meta/10_top.j2
+++ b/meta/10_top.j2
@@ -21,7 +21,11 @@
 {%   elif sshd[key] is defined %}
 {%     set value = sshd[key] %}
 {%   elif __sshd_defaults[key] is defined and not sshd_skip_defaults %}
-{%     set value = __sshd_defaults[key] %}
+{%     if key == 'HostKey' and __sshd_fips_mode %}
+{%       set value = __sshd_defaults[key] | difference(__sshd_hostkeys_nofips) %}
+{%     else %}
+{%       set value = __sshd_defaults[key] %}
+{%     endif %}
 {%   endif %}
 {{ render_option(key,value) -}}
 {% endmacro %}

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -22,8 +22,28 @@
     - __sshd_sysconfig_supports_use_strong_rng or __sshd_sysconfig_supports_crypto_policy
   notify: reload_sshd
 
+- name: Check the kernel FIPS mode
+  slurp:
+    src: /proc/sys/crypto/fips_enabled
+  register: __sshd_kernel_fips_mode
+  failed_when: false
+  when:
+    - __sshd_hostkeys_nofips != []
+
+- name: Check the userspace FIPS mode
+  slurp:
+    src: /etc/system-fips
+  register: __sshd_userspace_fips_mode
+  failed_when: false
+  when:
+    - __sshd_hostkeys_nofips != []
+
 - name: Make sure hostkeys are available and have expected permissions
   vars: &share_vars
+    __sshd_fips_mode: >-
+      __sshd_hostkeys_nofips != [] and \
+      (__sshd_kernel_fips_mode.content | b64decode == "1" | bool or \
+       __sshd_kernel_fips_mode.content | b64decode != "0" | bool)
     # This mimics the macro body_option() in sshd_config.j2
     # The explicit to_json filter is needed for Python 2 compatibility
     __sshd_hostkeys_from_config: >-
@@ -32,7 +52,11 @@
       {% elif sshd['HostKey'] is defined %}
         {{ sshd['HostKey'] | to_json }}
       {% elif __sshd_defaults['HostKey'] is defined and not sshd_skip_defaults %}
-        {{ __sshd_defaults['HostKey'] | to_json }}
+        {% if __sshd_fips_mode %}
+          {{ __sshd_defaults['HostKey'] | difference(__sshd_hostkeys_nofips) | to_json }}
+        {% else %}
+          {{ __sshd_defaults['HostKey'] | to_json }}
+        {% endif %}
       {% else %}
         []
       {% endif %}

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -28,7 +28,7 @@
   register: __sshd_kernel_fips_mode
   failed_when: false
   when:
-    - __sshd_hostkeys_nofips != []
+    - __sshd_hostkeys_nofips | d([])
 
 - name: Check the userspace FIPS mode
   slurp:
@@ -36,14 +36,14 @@
   register: __sshd_userspace_fips_mode
   failed_when: false
   when:
-    - __sshd_hostkeys_nofips != []
+    - __sshd_hostkeys_nofips | d([])
 
 - name: Make sure hostkeys are available and have expected permissions
   vars: &share_vars
     __sshd_fips_mode: >-
-      __sshd_hostkeys_nofips != [] and \
-      (__sshd_kernel_fips_mode.content | b64decode == "1" | bool or \
-       __sshd_kernel_fips_mode.content | b64decode != "0" | bool)
+      - __sshd_hostkeys_nofips | d([])
+      - __sshd_kernel_fips_mode.content | b64decode == "1" | bool or \
+        __sshd_userspace_fips_mode.content | b64decode != "0" | bool
     # This mimics the macro body_option() in sshd_config.j2
     # The explicit to_json filter is needed for Python 2 compatibility
     __sshd_hostkeys_from_config: >-

--- a/tests/requirements.yml
+++ b/tests/requirements.yml
@@ -1,0 +1,3 @@
+---
+collections:
+  - name: ansible.posix

--- a/tests/tests_hostkeys_fips.yml
+++ b/tests/tests_hostkeys_fips.yml
@@ -1,0 +1,103 @@
+---
+- hosts: all
+  vars:
+    __sshd_test_backup_files:
+      - /etc/ssh/sshd_config
+      - /etc/ssh/sshd_config.d/00-ansible_system_role.conf
+      - /etc/ssh/ssh_host_ed255519_key
+      - /etc/ssh/ssh_host_ed255519_key.pub
+      - /etc/system-fips
+  tasks:
+    - name: "Backup configuration files"
+      include_tasks: tasks/backup.yml
+
+    - name: Fake FIPS mode
+      block:
+        - name: Create temporary directory
+          tempfile:
+            state: directory
+          register: fips_directory
+
+        - name: Create a /etc/system-fips
+          copy:
+            dest: /etc/system-fips
+            content: userspace fips
+
+        - name: Create a fips_enabled file
+          copy:
+            dest: "{{ fips_directory.path }}/fips_enabled"
+            content: 1
+
+        - name: Bind mount the file where we need it
+          mount:
+            path: /proc/sys/crypto/fips_enabled
+            src: "{{ fips_directory.path }}/fips_enabled"
+            opts: bind
+            state: mounted
+            fstype: none
+          failed_when: false
+
+    - name: Remove the Ed25519 hostkey
+      file:
+        path:
+          /etc/ssh/ssh_host_ed255519_key
+        state: absent
+
+    - name: Remove the Ed25519 pubkey
+      file:
+        path:
+          /etc/ssh/ssh_host_ed255519_key.pub
+        state: absent
+
+    - name: Run the role with default parameters
+      include_role:
+        name: ansible-sshd
+
+    - name: Verify the options are correctly set
+      block:
+        - meta: flush_handlers
+
+        - name: Print current configuration file
+          slurp:
+            src: "{{ main_sshd_config }}"
+          register: config
+
+        - name: Get stat of private key
+          stat:
+            path: /etc/ssh/ssh_host_ed255519_key
+          register: privkey
+
+        - name: Get stat of public key
+          stat:
+            path: /etc/ssh/ssh_host_ed255519_key.pub
+          register: pubkey
+
+        - name: Check the key is not in configuration file
+          assert:
+            that:
+              - "'HostKey /etc/ssh/ssh_host_ed255519_key' not in config.content | b64decode"
+
+        - name: Check no host key was generated
+          assert:
+            that:
+              - not privkey.stat.exists
+              - not pubkey.stat.exists
+      when:
+        - ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution_major_version'] in ['7', '8']
+      tags: tests::verify
+
+    - name: Remove the FIPS mode indicators
+      block:
+        - name: Unmount the file
+          mount:
+            path: /proc/sys/crypto/fips_enabled
+            state: unmounted
+          failed_when: false
+
+        - name: Remove the temporary directory
+          file:
+            path: "{{ fips_directory.path }}"
+            state: absent
+
+    - name: "Restore configuration files"
+      include_tasks: tasks/restore.yml

--- a/vars/RedHat_7.yml
+++ b/vars/RedHat_7.yml
@@ -29,3 +29,5 @@ __sshd_os_supported: yes
 __sshd_sysconfig_supports_use_strong_rng: true
 __sshd_hostkey_group: ssh_keys
 __sshd_hostkey_mode: "0640"
+__sshd_hostkeys_nofips:
+  - /etc/ssh/ssh_host_ed25519_key

--- a/vars/RedHat_8.yml
+++ b/vars/RedHat_8.yml
@@ -31,3 +31,5 @@ __sshd_sysconfig_supports_use_strong_rng: true
 __sshd_sysconfig_supports_crypto_policy: true
 __sshd_hostkey_group: ssh_keys
 __sshd_hostkey_mode: "0640"
+__sshd_hostkeys_nofips:
+  - /etc/ssh/ssh_host_ed25519_key

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -7,3 +7,5 @@ __sshd_hostkey_group: "root"
 __sshd_hostkey_mode: "0600"
 # The OpenSSH 5.3 in RHEL6 does not support "Match all" so we need a workaround
 __sshd_compat_match_all: Match all
+# The hostkeys not supported in FIPS mode, if applicable
+__sshd_hostkeys_nofips: []


### PR DESCRIPTION
Previously, some of our users reported that this role has issues on FIPS systems, because it tries to generate Ed25519 keys, which are not allowed:

https://github.com/linux-system-roles/linux-system-roles.github.io/issues/66

There is a simple workaround to define list of hostkeys excluding this key type such as
```
sshd_HostKey:
  - /etc/ssh/ssh_host_rsa_key
  - /etc/ssh/ssh_host_ecdsa_key
```
but the defaults of the role should be FIPS aware.

The complicated thing is the FIPS detection. There are various things that are checked by the applications to turn on the FIPS mode, but generally, the kernel-space FIPS indication in `/proc/sys/crypto/fips_enabled` is most authoritative and universal place to check across different RHEL versions. Unfortunately, faking this does not work in Github Actions containers so I introduced also a check for `/etc/system-fips`, which should be also present in RHEL8.

The attached is also a testcase, which is trying to "fake" fips mode with bind mounts and verify the file is not generated. This is applicable only for RHEL7 and RHEL8 as older versions do not have the Ed25519 keys and newer versions already use drop-in directory. Note, that this does not work in the GitHub Actions (therefore the `fail_when: false`, but it should do the job on real RHEL images.