### PR TITLE
Ensure values are cast to correct type

### DIFF
--- a/templates/sshd_config.j2
+++ b/templates/sshd_config.j2
@@ -7,10 +7,10 @@
 {%     elif value is sameas false %}
 {{ key }} no
 {%     elif value is string or value is number %}
-{{ key }} {{ value }}
+{{ key }} {{ value | string }}
 {%     else %}
 {%       for i in value %}
-{{ key }} {{ i }}
+{{ key }} {{ i | string }}
 {%       endfor %}
 {%     endif %}
 {%   endif %}

--- a/templates/sshd_config_snippet.j2
+++ b/templates/sshd_config_snippet.j2
@@ -6,10 +6,10 @@
 {%     elif value is sameas false %}
 {{ key }} no
 {%     elif value is string or value is number %}
-{{ key }} {{ value }}
+{{ key }} {{ value | string }}
 {%     else %}
 {%       for i in value %}
-{{ key }} {{ i }}
+{{ key }} {{ i | string }}
 {%       endfor %}
 {%     endif %}
 {%   endif %}

--- a/templates/sysconfig.j2
+++ b/templates/sysconfig.j2
@@ -1,6 +1,6 @@
 {{ ansible_managed | comment }}
 {% if __sshd_sysconfig_supports_crypto_policy %}
-{%   if sshd_sysconfig_override_crypto_policy == true %}
+{%   if sshd_sysconfig_override_crypto_policy | bool %}
 CRYPTO_POLICY=
 {%   endif %}
 {% endif %}


### PR DESCRIPTION
https://github.com/willshersystems/ansible-sshd/issues/188
Ensure values are cast to string using `| string`
This shouldn't be necessary, but there seems no way to
guarantee using a version of Jinja which doesn't have this
problem.

In addition - it is not good practice to compare values to
`true` or `false` - instead, just ensure the value is a `bool`
type and evaluate in a boolean context.
