### PR TITLE
Version v0.17.0 - CHANGELOG.md [citest skip]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,31 @@
 Changelog
 =========
 
+[v0.17.0] - 2022-08-31
+--------------------
+
+### New Features
+
+- Make drop-in config file functionality configurable by user
+
+This PR simplifies the logic behind the drop-in config files and also
+allows the user to use drop-in configs even if the distribution does not
+support it out of the box.
+
+### Bug Fixes
+
+- Allow user to override variables
+
+A previous commit hardcoded many variables to the values under vars/,
+making it impossible for the user to parameterize things like the systemd
+service name. The assumption was that the __sshd_* variables were useless
+in an effort to blindly adhere to best practices, but they were crucial in
+allowing flexibility to the user.
+
+### Other Changes
+
+- none
+
 [v0.16.1] - 2022-07-28
 --------------------
 


### PR DESCRIPTION
[v0.17.0] - 2022-08-31
--------------------

### New Features

- Make drop-in config file functionality configurable by user

This PR simplifies the logic behind the drop-in config files and also
allows the user to use drop-in configs even if the distribution does not
support it out of the box.

### Bug Fixes

- Allow user to override variables

A previous commit hardcoded many variables to the values under vars/,
making it impossible for the user to parameterize things like the systemd
service name. The assumption was that the __sshd_* variables were useless
in an effort to blindly adhere to best practices, but they were crucial in
allowing flexibility to the user.

- Ensure values are cast to correct type

https://github.com/willshersystems/ansible-sshd/issues/188
This shouldn't be necessary, but there seems no way to
guarantee using a version of Jinja which doesn't have this
problem.

In addition - it is not good practice to compare values to
`true` or `false` - instead, just ensure the value is a `bool`
type and evaluate in a boolean context.

### Other Changes

- Fix various linting issues

- Revert incorrect module name

- tests: Do not be picky about spaces/tabs

When testing with cloud-init, it modifies the sshd_configuration and can
replace some tabs with whitespaces. This happens frequently around the
subsystem keyword. There are no functional changes, but the matching
did not work as expected.

- Fix ansible-lint warnings

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
