### PR TITLE
Fix new linting issues

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,6 +1,7 @@
 ---
 galaxy_info:
   role_name: sshd
+  namespace: willshersystems
   author: Matt Willsher
   description: OpenSSH SSH daemon configuration
   company: Willsher Systems

--- a/tasks/install_service.yml
+++ b/tasks/install_service.yml
@@ -1,5 +1,6 @@
 ---
 - name: Install systemd service files
+  when: sshd_install_service | bool
   block:
     - name: Install service unit file
       ansible.builtin.template:
@@ -25,7 +26,6 @@
         group: root
         mode: "0644"
       notify: reload_sshd
-  when: sshd_install_service | bool
 
 - name: Service enabled and running
   ansible.builtin.service:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,5 @@
 ---
 
-- ansible.builtin.include_tasks: sshd.yml
+- name: Invoke the role, if enabled
+  ansible.builtin.include_tasks: sshd.yml
   when: sshd_enable|bool


### PR DESCRIPTION
One of the issues is visible in the latest run of ansible-lint:
```
ERROR    Computed fully qualified role name of sshd does not follow current galaxy requirements.
Please edit meta/main.yml and assure we can correctly determine full role name:

galaxy_info:
role_name: my_name  # if absent directory name hosting role is used instead
namespace: my_galaxy_namespace  # if absent, author is used instead
```
where the ansible lint did not manage to figure out the namespace (probably). When executing the lint again, I got another warnings that I fixed too