### PR TITLE
Add check for non-inclusive language; Clean up / Workaround non-inclusive words

### DIFF
--- a/.github/workflows/woke.yml
+++ b/.github/workflows/woke.yml
@@ -1,0 +1,18 @@
+# yamllint disable rule:line-length
+name: Check for non-inclusive language
+on:  # yamllint disable-line rule:truthy
+  - pull_request
+jobs:
+  woke:
+    name: woke
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: woke
+        uses: get-woke/woke-action@v0
+        with:
+          woke-args: "-c https://raw.githubusercontent.com/linux-system-roles/tox-lsr/main/src/tox_lsr/config_files/woke.yml"
+          # Cause the check to fail on any broke rules
+          fail-on-error: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -283,7 +283,7 @@ a new release.
 
 ### Other Changes
 
-- Implement more sanity tests
+- Implement more coherence check tests
 
 [v0.10.1] - 2020-09-23
 ----------------------

--- a/tests/tests_include_present.yml
+++ b/tests/tests_include_present.yml
@@ -98,7 +98,7 @@
     - name: "Backup configuration files"
       ansible.builtin.include_tasks: tasks/backup.yml
 
-    - name: Create dummy main configuration file
+    - name: Create sample main configuration file
       # Normally, this should not be needed. For test, however, we need a file
       # different to the one in the first play.
       file:


### PR DESCRIPTION
Add check for non-inclusive language
    
Add a check for usage of terms and language that is considered non-inclusive. We are using the woke tool for this with a wordlist that can be found at
https://github.com/linux-system-roles/tox-lsr/blob/main/src/tox_lsr/config_files/woke.yml

Clean up / Workaround non-inclusive words
- CHANGELOG.md
- tests/tests_include_present.yml