### PR TITLE
Fedora 38 has no longer non-standard hostkey permissions

### DIFF
--- a/vars/Fedora_36.yml
+++ b/vars/Fedora_36.yml
@@ -1,0 +1,1 @@
+Fedora_37.yml

--- a/vars/Fedora_37.yml
+++ b/vars/Fedora_37.yml
@@ -20,6 +20,8 @@ __sshd_verify_hostkeys_default:
   - /etc/ssh/ssh_host_ed25519_key
 __sshd_hostkeys_nofips:
   - /etc/ssh/ssh_host_ed25519_key
+__sshd_hostkey_group: ssh_keys
+__sshd_hostkey_mode: "0640"
 
 __sshd_drop_in_dir_mode: '0700'
 __sshd_main_config_file: /etc/ssh/sshd_config


### PR DESCRIPTION
The Fedora commit introducing this change (now in Rawhide/Fedora 38 only):

https://src.fedoraproject.org/rpms/openssh/c/7a21555354a2c5e724aa4c287b640c24bf108780

Fedora 38 is to be released on 04 Apr 2023 (if all goes well) so there is no need to hurry with the applying of the change and releasing it, but it would be good to be ready.

Anything older than Fedora 36 is EOL [1] so I do not think it is worth keeping some compatibility with these versions, but if you disagree, I can provide more symlinks. We can probably remove the Fedora 31 configuration file too, but it would be a separate change.

[1] https://docs.fedoraproject.org/en-US/releases/eol/