### PR TITLE
Fingerprint ansible-sshd managed config files

### DIFF
--- a/meta/01_ansible_head.j2
+++ b/meta/01_ansible_head.j2
@@ -1,1 +1,2 @@
 {{ ansible_managed | comment }}
+{{ "willshersystems:ansible-sshd" | comment(prefix="", postfix="") }}

--- a/templates/sshd_config.j2
+++ b/templates/sshd_config.j2
@@ -1,4 +1,5 @@
 {{ ansible_managed | comment }}
+{{ "willshersystems:ansible-sshd" | comment(prefix="", postfix="") }}
 {% macro render_option(key,value,indent=false) %}
 {%   if value is defined %}
 {%     if indent %}  {% endif %}

--- a/templates/sysconfig.j2
+++ b/templates/sysconfig.j2
@@ -1,4 +1,5 @@
 {{ ansible_managed | comment }}
+{{ "willshersystems:ansible-sshd" | comment(prefix="", postfix="") }}
 {% if __sshd_sysconfig_supports_crypto_policy %}
 {%   if sshd_sysconfig_override_crypto_policy | bool %}
 CRYPTO_POLICY=


### PR DESCRIPTION
Add repo and role name to the generated config files.
```
# willshersystems:ansible-sshd
```
Note: This information is provided to help customers identify that it was generated by ansible-sshd role. It may also be used for future analysis.