### PR TITLE
Make sure the list options are correctly indented

### DIFF
--- a/meta/10_top.j2
+++ b/meta/10_top.j2
@@ -1,14 +1,17 @@
 {% macro render_option(key,value,indent=false) %}
 {%   if value is defined %}
-{%     if indent %}  {% endif %}
 {%     if value is sameas true %}
+{%     if indent %}  {% endif %}
 {{ key }} yes
 {%     elif value is sameas false %}
+{%     if indent %}  {% endif %}
 {{ key }} no
 {%     elif value is string or value is number %}
+{%     if indent %}  {% endif %}
 {{ key }} {{ value | string }}
 {%     else %}
 {%       for i in value %}
+{%     if indent %}  {% endif %}
 {{ key }} {{ i | string }}
 {%       endfor %}
 {%     endif %}

--- a/templates/sshd_config.j2
+++ b/templates/sshd_config.j2
@@ -2,15 +2,18 @@
 {{ "willshersystems:ansible-sshd" | comment(prefix="", postfix="") }}
 {% macro render_option(key,value,indent=false) %}
 {%   if value is defined %}
-{%     if indent %}  {% endif %}
 {%     if value is sameas true %}
+{%     if indent %}  {% endif %}
 {{ key }} yes
 {%     elif value is sameas false %}
+{%     if indent %}  {% endif %}
 {{ key }} no
 {%     elif value is string or value is number %}
+{%     if indent %}  {% endif %}
 {{ key }} {{ value | string }}
 {%     else %}
 {%       for i in value %}
+{%     if indent %}  {% endif %}
 {{ key }} {{ i | string }}
 {%       endfor %}
 {%     endif %}

--- a/templates/sshd_config_snippet.j2
+++ b/templates/sshd_config_snippet.j2
@@ -1,14 +1,17 @@
 {% macro render_option(key,value,indent=true) %}
 {%   if value is defined %}
-{%     if indent %}  {% endif %}
 {%     if value is sameas true %}
+{%     if indent %}  {% endif %}
 {{ key }} yes
 {%     elif value is sameas false %}
+{%     if indent %}  {% endif %}
 {{ key }} no
 {%     elif value is string or value is number %}
+{%     if indent %}  {% endif %}
 {{ key }} {{ value | string }}
 {%     else %}
 {%       for i in value %}
+{%     if indent %}  {% endif %}
 {{ key }} {{ i | string }}
 {%       endfor %}
 {%     endif %}

--- a/tests/tests_indent.yml
+++ b/tests/tests_indent.yml
@@ -16,12 +16,22 @@
         sshd:
           PasswordAuthentication: true
           PermitRootLogin: true
+          AcceptEnv:
+            - TEST
+            - LC_ALL
           Match:
             Condition: user root
             AllowAgentForwarding: false
+            AcceptEnv:
+              - TESTENV
+              - LANG
+      when:
+        - not (ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution_major_version'] == '6')
 
     - name: Verify the options are correctly set
       tags: tests::verify
+      when:
+        - not (ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution_major_version'] == '6')
       block:
         - name: Flush handlers
           ansible.builtin.meta: flush_handlers
@@ -34,9 +44,16 @@
         - name: Check the options are correctly indented in configuration file
           ansible.builtin.assert:
             that:
-              - "config.content | b64decode | regex_search('^PasswordAuthentication yes$', multiline=True)"
-              - "config.content | b64decode | regex_search('^PermitRootLogin yes$', multiline=True)"
-              - "config.content | b64decode | regex_search('^Match user root\\n\\s+AllowAgentForwarding no$', multiline=True)"
+              - content is search ('^PasswordAuthentication yes$', multiline=True)
+              - content is search ('^PermitRootLogin yes$', multiline=True)
+              - content is search ("^AcceptEnv TEST$", multiline=True)
+              - content is search ("^AcceptEnv LC_ALL$", multiline=True)
+              - content is search ('^Match user root$', multiline=True)
+              - content is search ("^  AcceptEnv TESTENV$", multiline=True)
+              - content is search ("^  AcceptEnv LANG$", multiline=True)
+              - content is search ('^  AllowAgentForwarding no$', multiline=True)
+          vars:
+            content: "{{ config.content | b64decode }}"
 
     - name: "Restore configuration files"
       ansible.builtin.include_tasks: tasks/restore.yml


### PR DESCRIPTION
Inspired by similar issue reported and fixed in ssh client role https://github.com/linux-system-roles/ssh/pull/80/

This wont work in RHEL6 (not allowed AcceptEnv in match blocks) so just skip it here.