### PR TITLE
ci: Drop testing on Debian stretch (9)

### DIFF
--- a/.github/workflows/ansible-debian-check.yml
+++ b/.github/workflows/ansible-debian-check.yml
@@ -28,16 +28,3 @@ jobs:
           group: local
           hosts: localhost
           targets: "tests/tests_*.yml"
-
-  debian-stretch:
-    runs-on: ubuntu-latest
-    steps:
-      - name: checkout PR
-        uses: actions/checkout@v3
-
-      - name: ansible check with debian stretch (9)
-        uses: roles-ansible/check-ansible-debian-stretch-action@master
-        with:
-          group: local
-          hosts: localhost
-          targets: "tests/tests_*.yml"


### PR DESCRIPTION
This version is EOL since last year and various failures happen.

Fixes: #228