### PR TITLE
ci: Add pull request template and run commitlint on PR title only

### DIFF
--- a/.commitlintrc.js
+++ b/.commitlintrc.js
@@ -30,6 +30,7 @@ module.exports = {
 				'revert',
 				'style',
 				'test',
+				'tests',
 			],
 		],
 	},
@@ -71,6 +72,11 @@ module.exports = {
 						emoji: '🚀',
 					},
 					test: {
+						description: 'Adding missing tests or correcting existing tests',
+						title: 'Tests',
+						emoji: '🚨',
+					},
+					tests: {
 						description: 'Adding missing tests or correcting existing tests',
 						title: 'Tests',
 						emoji: '🚨',

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+Enhancement:
+
+Reason:
+
+Result:
+
+Issue Tracker Tickets (Jira or BZ if any):

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -11,6 +11,8 @@ on:  # yamllint disable-line rule:truthy
       - main
     types:
       - checks_requested
+permissions:
+  contents: read
 jobs:
   commit-checks:
     runs-on: ubuntu-latest
@@ -22,20 +24,8 @@ jobs:
       - name: Install conventional-commit linter
         run: npm install @commitlint/config-conventional @commitlint/cli
 
-      # Finding the commit range is not as trivial as it may seem.
-      #
-      # At this stage, git's HEAD does not refer to the latest commit in the
-      # PR, but rather to the merge commit inserted by the PR. So instead we
-      # have to get 'HEAD' from the PR event.
-      #
-      # One cannot use the number of commits
-      # (github.event.pull_request.commits) to find the start commit
-      # i.e. HEAD~N does not work, this breaks if there are merge commits.
-      - name: Run commitlint on commits
-        run: >-
-          npx commitlint --from '${{ github.event.pull_request.base.sha }}'
-          --to '${{ github.event.pull_request.head.sha }}' --verbose
-
       - name: Run commitlint on PR title
-        run: |
-          echo '${{ github.event.pull_request.title }}' | npx commitlint --verbose
+        run: >-
+          echo '${{ github.event.pull_request.title }}' |
+          npx commitlint --verbose
+


### PR DESCRIPTION
We now ensure the conventional commits format only on PR titles and not on
commits to let developers keep commit messages targeted for other developers
i.e. describe actual changes to code that users should not care about.
And PR titles, on the contrary, must be aimed at end users.

For more info, see
https://linux-system-roles.github.io/contribute.html#write-a-good-pr-title-and-description