### PR TITLE
feat: debian 12 support and small config fixes for debian

### DIFF
--- a/.github/workflows/ansible-debian-check.yml
+++ b/.github/workflows/ansible-debian-check.yml
@@ -3,6 +3,19 @@ name: Run tests on Debian
 on: [push, pull_request]
 
 jobs:
+  debian-bookworm:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout PR
+        uses: actions/checkout@v3
+
+      - name: ansible check with debian bookworm (12)
+        uses: roles-ansible/check-ansible-debian-bookworm-action@v1
+        with:
+          group: local
+          hosts: localhost
+          targets: "tests/tests_*.yml"
+
   debian-bullseye:
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Tested on:
 
 * Ubuntu precise, trusty, xenial, bionic, focal, jammy
   * [![Run tests on Ubuntu latest](https://github.com/willshersystems/ansible-sshd/actions/workflows/ansible-ubuntu.yml/badge.svg)](https://github.com/willshersystems/ansible-sshd/actions/workflows/ansible-ubuntu.yml)
-* Debian wheezy, jessie, stretch, buster, bullseye
+* Debian wheezy, jessie, stretch, buster, bullseye, bookworm
   * [![Run tests on Debian](https://github.com/willshersystems/ansible-sshd/actions/workflows/ansible-debian-check.yml/badge.svg)](https://github.com/willshersystems/ansible-sshd/actions/workflows/ansible-debian-check.yml)
 * EL 6, 7, 8, 9 derived distributions
   * [![Run tests on CentOS](https://github.com/willshersystems/ansible-sshd/actions/workflows/ansible-centos-check.yml/badge.svg)](https://github.com/willshersystems/ansible-sshd/actions/workflows/ansible-centos-check.yml)

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -15,6 +15,7 @@ galaxy_info:
         - stretch
         - buster
         - bullseye
+        - bookworm
     - name: Ubuntu
       versions:
         - precise

--- a/tests/tasks/setup.yml
+++ b/tests/tasks/setup.yml
@@ -1,4 +1,10 @@
 ---
+- name: Ensure apt sources are up to date on debian systems
+  ansible.builtin.apt:
+    update_cache: true
+  when:
+    - ansible_facts['distribution'] == 'Debian'
+
 - name: Make sure openssh is installed before creating backup
   ansible.builtin.package:
     name: openssh-server

--- a/vars/Debian_10.yml
+++ b/vars/Debian_10.yml
@@ -6,10 +6,10 @@ __sshd_packages:
 __sshd_config_mode: "0644"
 __sshd_defaults:
   ChallengeResponseAuthentication: false
+  UsePAM: true
   X11Forwarding: true
   PrintMotd: false
   AcceptEnv: LANG LC_*
   Subsystem: "sftp {{ __sshd_sftp_server }}"
-  UsePAM: true
 __sshd_os_supported: true
 __sshd_runtime_directory: /run/sshd

--- a/vars/Debian_11.yml
+++ b/vars/Debian_11.yml
@@ -5,11 +5,12 @@ __sshd_packages:
   - openssh-sftp-server
 __sshd_config_mode: "0644"
 __sshd_defaults:
+  Include: /etc/ssh/sshd_config.d/*.conf
   ChallengeResponseAuthentication: false
+  UsePAM: true
   X11Forwarding: true
   PrintMotd: false
   AcceptEnv: LANG LC_*
   Subsystem: "sftp {{ __sshd_sftp_server }}"
-  UsePAM: true
 __sshd_os_supported: true
 __sshd_runtime_directory: /run/sshd

--- a/vars/Debian_12.yml
+++ b/vars/Debian_12.yml
@@ -1,0 +1,16 @@
+---
+__sshd_service: ssh
+__sshd_packages:
+  - openssh-server
+  - openssh-sftp-server
+__sshd_config_mode: "0644"
+__sshd_defaults:
+  Include: /etc/ssh/sshd_config.d/*.conf
+  KbdInteractiveAuthentication: false
+  UsePAM: true
+  X11Forwarding: true
+  PrintMotd: false
+  AcceptEnv: LANG LC_*
+  Subsystem: "sftp {{ __sshd_sftp_server }}"
+__sshd_os_supported: true
+__sshd_runtime_directory: /run/sshd


### PR DESCRIPTION
This PR adds Debian 12 (aka bookworm) support to the role.
The workflow fails at the moment because there is no roles-ansible/check-ansible-debian-bookworm-action repo yet. As soon as @DO1JLR has created the repo it should pass all checks.

Furthermore i fixed some small oversights in older debian defaults.