### PR TITLE
fix: Support inject_facts_as_vars = false

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -6,10 +6,10 @@
     state: reloaded
   when:
     - sshd_allow_reload|bool
-    - ansible_virtualization_type|default(None) not in __sshd_skip_virt_env
+    - ansible_facts['virtualization_type']|default(None) not in __sshd_skip_virt_env
     - ansible_connection != 'chroot'
-    - ansible_os_family != 'AIX'
-    - ansible_os_family != 'OpenWrt'
+    - ansible_facts['os_family'] != 'AIX'
+    - ansible_facts['os_family'] != 'OpenWrt'
   listen: reload_sshd
 
 # sshd on AIX cannot be 'reloaded', it must be Stopped+Started.
@@ -29,7 +29,7 @@
   changed_when: false
   when:
     - sshd_allow_reload|bool
-    - ansible_os_family == 'AIX'
+    - ansible_facts['os_family'] == 'AIX'
 
 # sshd on OpenWrt does not support reloading a service, it has to be restarted instead
 - name: Reload the SSH service (OpenWrt)
@@ -38,5 +38,5 @@
     state: restarted
   when:
     - sshd_allow_reload|bool
-    - ansible_os_family == 'OpenWrt'
+    - ansible_facts['os_family'] == 'OpenWrt'
   listen: reload_sshd

--- a/tasks/find_ports.yml
+++ b/tasks/find_ports.yml
@@ -23,4 +23,4 @@
   when:
     - sshd_manage_firewall | bool or sshd_manage_selinux | bool
     - ansible_facts['os_family'] == 'RedHat'
-    - ansible_virtualization_type|default(None) not in __sshd_skip_virt_env
+    - ansible_facts['virtualization_type']|default(None) not in __sshd_skip_virt_env

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -130,14 +130,14 @@
         - sshd_manage_firewall | bool
         - ansible_facts['os_family'] == 'RedHat'
         - ansible_facts['distribution_version'] is version('7', '>=')
-        - ansible_virtualization_type|default(None) not in __sshd_skip_virt_env
+        - ansible_facts['virtualization_type']|default(None) not in __sshd_skip_virt_env
 
     - name: Configure selinux
       ansible.builtin.include_tasks: selinux.yml
       when:
         - sshd_manage_selinux | bool
         - ansible_facts['os_family'] == 'RedHat'
-        - ansible_virtualization_type|default(None) not in __sshd_skip_virt_env
+        - ansible_facts['virtualization_type']|default(None) not in __sshd_skip_virt_env
 
     - name: Create the complete configuration file
       ansible.builtin.include_tasks: install_config.yml

--- a/tasks/install_service.yml
+++ b/tasks/install_service.yml
@@ -34,7 +34,7 @@
     state: started
   when:
     - sshd_manage_service|bool
-    - ansible_virtualization_type|default(None) not in __sshd_skip_virt_env
+    - ansible_facts['virtualization_type']|default(None) not in __sshd_skip_virt_env
     - ansible_connection != 'chroot'
 
 # Due to ansible bug 21026, cannot use service module on RHEL 7
@@ -42,6 +42,6 @@
   ansible.builtin.command: systemctl enable {{ sshd_service }}  # noqa command-instead-of-module
   when:
     - ansible_connection == 'chroot'
-    - ansible_os_family == 'RedHat'
-    - ansible_distribution_major_version|int >= 7
+    - ansible_facts['os_family'] == 'RedHat'
+    - ansible_facts['distribution_major_version']|int >= 7
   changed_when: true

--- a/tasks/variables.yml
+++ b/tasks/variables.yml
@@ -10,23 +10,23 @@
   vars:
     _distribution_lts_offset: >-
       {{
-        ansible_distribution_major_version | int % 2
-        if ansible_distribution == "Ubuntu"
+        ansible_facts['distribution_major_version'] | int % 2
+        if ansible_facts['distribution'] == "Ubuntu"
         else 0
       }}
     _distribution_lts_version: >-
       {{
-        ansible_distribution_major_version | int -
+        ansible_facts['distribution_major_version'] | int -
         _distribution_lts_offset | int
-        if ansible_distribution == "Ubuntu"
-        else ansible_distribution_version
+        if ansible_facts['distribution'] == "Ubuntu"
+        else ansible_facts['distribution_version']
       }}
     params:
       files:
-        - "{{ ansible_distribution }}_{{ _distribution_lts_version }}.yml"
-        - "{{ ansible_os_family }}_{{ ansible_distribution_major_version }}.yml"
-        - "{{ ansible_distribution }}.yml"
-        - "{{ ansible_os_family }}.yml"
+        - "{{ ansible_facts['distribution'] }}_{{ _distribution_lts_version }}.yml"
+        - "{{ ansible_facts['os_family'] }}_{{ ansible_facts['distribution_major_version'] }}.yml"
+        - "{{ ansible_facts['distribution'] }}.yml"
+        - "{{ ansible_facts['os_family'] }}.yml"
         - main.yml  # fallback, vars/main.yml is always loaded by Ansible
       paths:
         - "{{ role_path }}/vars"

--- a/tasks/variables.yml
+++ b/tasks/variables.yml
@@ -8,22 +8,22 @@
 - name: Set OS dependent variables
   ansible.builtin.include_vars: "{{ lookup('first_found', params) }}"
   vars:
-    ansible_distribution_lts_offset: >-
+    _distribution_lts_offset: >-
       {{
         ansible_distribution_major_version | int % 2
         if ansible_distribution == "Ubuntu"
         else 0
       }}
-    ansible_distribution_lts_version: >-
+    _distribution_lts_version: >-
       {{
         ansible_distribution_major_version | int -
-        ansible_distribution_lts_offset | int
+        _distribution_lts_offset | int
         if ansible_distribution == "Ubuntu"
         else ansible_distribution_version
       }}
     params:
       files:
-        - "{{ ansible_distribution }}_{{ ansible_distribution_lts_version }}.yml"
+        - "{{ ansible_distribution }}_{{ _distribution_lts_version }}.yml"
         - "{{ ansible_os_family }}_{{ ansible_distribution_major_version }}.yml"
         - "{{ ansible_distribution }}.yml"
         - "{{ ansible_os_family }}.yml"

--- a/tests/tasks/restore.yml
+++ b/tests/tasks/restore.yml
@@ -38,6 +38,6 @@
   changed_when: false
   when:
     - __sshd_test_backup is defined
-    - ansible_virtualization_type|default(None) not in __sshd_skip_virt_env
+    - ansible_facts['virtualization_type']|default(None) not in __sshd_skip_virt_env
     - ansible_connection != 'chroot'
-    - ansible_os_family != 'AIX'
+    - ansible_facts['os_family'] != 'AIX'

--- a/tests/tests_firewall_selinux.yml
+++ b/tests/tests_firewall_selinux.yml
@@ -22,10 +22,10 @@
         sshd_enable: true  # reset to true
         __sshd_test_firewall: "{{ ansible_facts['os_family'] == 'RedHat' and
           ansible_facts['distribution_version'] is version('7', '>=') and
-          ansible_virtualization_type | d(None) not in __sshd_skip_virt_env }}"
+          ansible_facts['virtualization_type'] | d(None) not in __sshd_skip_virt_env }}"
         __sshd_test_selinux: "{{ ansible_facts['os_family'] == 'RedHat' and
           ansible_facts['distribution_version'] is version('6', '>=') and
-          ansible_virtualization_type | d(None) not in __sshd_skip_virt_env }}"
+          ansible_facts['virtualization_type'] | d(None) not in __sshd_skip_virt_env }}"
 
     ##########
     # First test: default port


### PR DESCRIPTION
Enhancement:

Support `inject_facts_as_vars = false` in ansible.cfg.

The setting is considered safer because a compromised host cannot inject facts into variables.

Reason:

Minor security enhancement.

This setting is also recommended in some tuning guides like
https://docs.openstack.org/kolla-ansible/wallaby/user/ansible-tuning.html#fact-variable-injection
and issue mitigation guides:
https://docs.ansible.com/ansible/latest/reference_appendices/faq.html#when-is-it-unsafe-to-bulk-set-task-arguments-from-a-variable

`ansible_facts` are used only with one name. Previously for example `ansible_facts['os_family']` was also used as `ansible_os_family`. This helps maintainability.

Result:

Support `inject_facts_as_vars = false`. If setting is `true`, situation still works as expected.

Also drop `ansible` prefix from local variables to avoid possible conflicts in namespace and avoid possible confusion.

Issue Tracker Tickets (Jira or BZ if any): -
