### PR TITLE
ci: Ignore var-naming[no-role-prefix] ansible-lint rule that fails expectedly

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,3 +1,5 @@
 exclude_paths:
   - tests/roles/
   - .tox/
+skip_list:
+  - var-naming[no-role-prefix]


### PR DESCRIPTION
Enhancement: Ignore var-naming[no-role-prefix] ansible-lint rule that fails expectedly

Reason: ansible-lint recently added a rule `var-naming[no-role-prefix]` that fails expectedly, this role generally uses `sshd` instead of `ansible_sshd`, and also vars from other roles e.g. `firewall_`.

Result: ansible-lint ignores this rule and passes.
