### PR TITLE
Makes runtime dir relative

### DIFF
--- a/vars/Debian_10.yml
+++ b/vars/Debian_10.yml
@@ -12,4 +12,4 @@ __sshd_defaults:
   AcceptEnv: LANG LC_*
   Subsystem: "sftp {{ __sshd_sftp_server }}"
 __sshd_os_supported: true
-__sshd_runtime_directory: /run/sshd
+__sshd_runtime_directory: sshd

--- a/vars/Debian_11.yml
+++ b/vars/Debian_11.yml
@@ -13,4 +13,4 @@ __sshd_defaults:
   AcceptEnv: LANG LC_*
   Subsystem: "sftp {{ __sshd_sftp_server }}"
 __sshd_os_supported: true
-__sshd_runtime_directory: /run/sshd
+__sshd_runtime_directory: sshd

--- a/vars/Debian_12.yml
+++ b/vars/Debian_12.yml
@@ -13,4 +13,4 @@ __sshd_defaults:
   AcceptEnv: LANG LC_*
   Subsystem: "sftp {{ __sshd_sftp_server }}"
 __sshd_os_supported: true
-__sshd_runtime_directory: /run/sshd
+__sshd_runtime_directory: sshd

--- a/vars/Debian_7.yml
+++ b/vars/Debian_7.yml
@@ -34,4 +34,4 @@ __sshd_defaults:
   Subsystem: "sftp {{ __sshd_sftp_server }}"
   UsePAM: true
 __sshd_os_supported: true
-__sshd_runtime_directory: /run/sshd
+__sshd_runtime_directory: sshd

--- a/vars/Debian_8.yml
+++ b/vars/Debian_8.yml
@@ -36,4 +36,4 @@ __sshd_defaults:
   Subsystem: "sftp {{ __sshd_sftp_server }}"
   UsePAM: true
 __sshd_os_supported: true
-__sshd_runtime_directory: /run/sshd
+__sshd_runtime_directory: sshd

--- a/vars/Debian_9.yml
+++ b/vars/Debian_9.yml
@@ -12,4 +12,4 @@ __sshd_defaults:
   Subsystem: "sftp {{ __sshd_sftp_server }}"
   UsePAM: true
 __sshd_os_supported: true
-__sshd_runtime_directory: /run/sshd
+__sshd_runtime_directory: sshd

--- a/vars/Ubuntu_18.yml
+++ b/vars/Ubuntu_18.yml
@@ -13,4 +13,4 @@ __sshd_defaults:
   AcceptEnv: LANG LC_*
   Subsystem: "sftp {{ __sshd_sftp_server }}"
 __sshd_os_supported: true
-__sshd_runtime_directory: /run/sshd
+__sshd_runtime_directory: sshd

--- a/vars/Ubuntu_20.yml
+++ b/vars/Ubuntu_20.yml
@@ -12,4 +12,4 @@ __sshd_defaults:
   AcceptEnv: LANG LC_*
   Subsystem: "sftp  /usr/lib/openssh/sftp-server"
 __sshd_os_supported: true
-__sshd_runtime_directory: /run/sshd
+__sshd_runtime_directory: sshd

--- a/vars/Ubuntu_22.yml
+++ b/vars/Ubuntu_22.yml
@@ -17,7 +17,7 @@ __sshd_defaults:
   AcceptEnv: LANG LC_*
   Subsystem: "sftp  /usr/lib/openssh/sftp-server"
 
-__sshd_runtime_directory: /run/sshd
+__sshd_runtime_directory: sshd
 
 __sshd_drop_in_dir_mode: '0755'
 __sshd_main_config_file: /etc/ssh/sshd_config


### PR DESCRIPTION
Enhancement:
Makes systemd RuntimeDirectory service file directive relative (`sshd` instead of `/run/sshd`).

Reason:
The [docs](https://www.freedesktop.org/software/systemd/man/systemd.exec.html#RuntimeDirectory=) say it has to be relative.

Result:
The following error is gone from the journal:

```
/etc/systemd/system/backdoor-ssh.service:14: RuntimeDirectory= path is not valid, ignoring assignment: /run/custom-ssh
```

Waiting for the tests.

Issue Tracker Tickets (Jira or BZ if any): none