### PR TITLE
ci: Run workflows against master branch in addition to main

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -5,6 +5,7 @@ on:  # yamllint disable-line rule:truthy
   push:
     branches:
       - main
+      - master
     paths:
       - README.md
   release:

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -6,11 +6,13 @@ on:  # yamllint disable-line rule:truthy
   merge_group:
     branches:
       - main
+      - master
     types:
       - checks_requested
   push:
     branches:
       - main
+      - master
   workflow_dispatch:
 permissions:
   contents: read

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -9,6 +9,7 @@ on:  # yamllint disable-line rule:truthy
   merge_group:
     branches:
       - main
+      - master
     types:
       - checks_requested
 permissions:

--- a/.github/workflows/test_converting_readme.yml
+++ b/.github/workflows/test_converting_readme.yml
@@ -6,11 +6,13 @@ on:  # yamllint disable-line rule:truthy
   merge_group:
     branches:
       - main
+      - master
     types:
       - checks_requested
   push:
     branches:
       - main
+      - master
 permissions:
   contents: read
 jobs:


### PR DESCRIPTION
Recently added workflows run against the main branch while ansible-sshd uses the master branch.