### PR TITLE
Support socket activation with non-default ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,12 @@ Using these variables, you can use your own custom templates. With the above
 default templates, the name of the installed ssh service will be provided by
 the `sshd_service` variable.
 
+#### sshd_socket_activation
+
+If set to *true*, systemd's socket activation will be used to start service
+instances (`sshd.socket` activates `sshd@.service`) on each incoming connection
+instead running a single permanent service for all connections.
+
 #### sshd_manage_firewall
 
 If set to *true*, the the SSH port(s) will be opened in firewall. Note, this

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,6 +13,10 @@ sshd_manage_service: true
 # If the below is false, don't reload the ssh daemon on change
 sshd_allow_reload: true
 
+# If set to true, use systemd's socket activation and start a socket unit,
+# instead of the service unit
+sshd_socket_activation: "{{ __sshd_socket_activation | bool }}"
+
 # If the below is true, also install service files from the templates pointed
 # to by the `sshd_service_template_*` variables
 sshd_install_service: false

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,7 +2,7 @@
 
 - name: Reload the SSH service
   ansible.builtin.service:
-    name: "{{ sshd_service }}"
+    name: "{{ sshd_service }}{{ '.socket' if sshd_socket_activation | bool else '' }}"
     state: reloaded
   when:
     - sshd_allow_reload|bool

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,4 +1,12 @@
 ---
+- name: Reload systemd units
+  ansible.builtin.systemd:
+    daemon_reload: true
+  when:
+    - ansible_facts['virtualization_type'] | default(None) not in __sshd_skip_virt_env
+    - ansible_connection != 'chroot'
+    - ansible_facts['os_family'] not in ['AIX', 'OpenWrt']
+  listen: reload_units
 
 - name: Reload the SSH service
   ansible.builtin.service:

--- a/tasks/install_service.yml
+++ b/tasks/install_service.yml
@@ -29,7 +29,7 @@
 
 - name: Service enabled and running
   ansible.builtin.service:
-    name: "{{ sshd_service }}"
+    name: "{{ sshd_service }}{{ '.socket' if sshd_socket_activation | bool else '' }}"
     enabled: true
     state: started
   when:

--- a/tasks/install_service.yml
+++ b/tasks/install_service.yml
@@ -1,31 +1,34 @@
 ---
-- name: Install systemd service files
+- name: Install service unit file
+  ansible.builtin.template:
+    src: "{{ sshd_service_template_service }}"
+    dest: "/etc/systemd/system/{{ sshd_service }}.service"
+    owner: root
+    group: root
+    mode: "0644"
+  notify: reload_sshd
   when: sshd_install_service | bool
-  block:
-    - name: Install service unit file
-      ansible.builtin.template:
-        src: "{{ sshd_service_template_service }}"
-        dest: "/etc/systemd/system/{{ sshd_service }}.service"
-        owner: root
-        group: root
-        mode: "0644"
-      notify: reload_sshd
-    - name: Install instanced service unit file
-      ansible.builtin.template:
-        src: "{{ sshd_service_template_at_service }}"
-        dest: "/etc/systemd/system/{{ sshd_service }}@.service"
-        owner: root
-        group: root
-        mode: "0644"
-      notify: reload_sshd
-    - name: Install socket unit file
-      ansible.builtin.template:
-        src: "{{ sshd_service_template_socket }}"
-        dest: "/etc/systemd/system/{{ sshd_service }}.socket"
-        owner: root
-        group: root
-        mode: "0644"
-      notify: reload_sshd
+- name: Install instanced service unit file
+  ansible.builtin.template:
+    src: "{{ sshd_service_template_at_service }}"
+    dest: "/etc/systemd/system/{{ sshd_service }}@.service"
+    owner: root
+    group: root
+    mode: "0644"
+  notify: reload_sshd
+  when: sshd_install_service | bool
+- name: Install socket unit file
+  ansible.builtin.template:
+    src: "{{ sshd_service_template_socket }}"
+    dest: "/etc/systemd/system/{{ sshd_service }}.socket"
+    owner: root
+    group: root
+    mode: "0644"
+  notify: reload_sshd
+  when:
+    - (sshd_install_service | bool is truthy ) or
+      (( __sshd_ports_from_config | from_json != [22] ) and
+      ( sshd_socket_activation | bool is truthy ))
 
 - name: Service enabled and running
   ansible.builtin.service:

--- a/tasks/install_service.yml
+++ b/tasks/install_service.yml
@@ -6,7 +6,9 @@
     owner: root
     group: root
     mode: "0644"
-  notify: reload_sshd
+  notify:
+  - reload_units
+  - reload_sshd
   when: sshd_install_service | bool
 - name: Install instanced service unit file
   ansible.builtin.template:
@@ -15,7 +17,9 @@
     owner: root
     group: root
     mode: "0644"
-  notify: reload_sshd
+  notify:
+  - reload_units
+  - reload_sshd
   when: sshd_install_service | bool
 - name: Install socket unit file
   ansible.builtin.template:
@@ -24,7 +28,9 @@
     owner: root
     group: root
     mode: "0644"
-  notify: reload_sshd
+  notify:
+  - reload_units
+  - reload_sshd
   when:
     - (sshd_install_service | bool is truthy ) or
       (( __sshd_ports_from_config | from_json != [22] ) and

--- a/templates/sshd.socket.j2
+++ b/templates/sshd.socket.j2
@@ -5,7 +5,9 @@ Before={{ sshd_service }}.service
 Conflicts={{ sshd_service }}.service
 
 [Socket]
-ListenStream=22
+{% for port in __sshd_ports_from_config | from_json %}
+ListenStream={{ port }}
+{% endfor %}
 Accept=yes
 
 [Install]

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -36,6 +36,7 @@ __sshd_skip_virt_env:
 
 __sshd_binary: /usr/sbin/sshd
 __sshd_service: sshd
+__sshd_socket_activation: false
 __sshd_sftp_server: /usr/lib/openssh/sftp-server
 
 __sshd_defaults: {}


### PR DESCRIPTION
Enhancement:
Control via the var `sshd_socket_activation` whether SSH should run as a single permanent service or whether on each incoming connection request, a new instance of `sshd@.service` should be spawned.

Reason:
This improves security, allows for easier per-connection troubleshooting and eliminates the need to restart the service after config changes.

Result:
- `sshd.socket` is running, `sshd.service` is not
- on each connection, a service instance like `sshd@1-10.13.13.5:22-192.168.178.53:44876.service` is spawned

Issue Tracker Tickets (Jira or BZ if any): -
