### PR TITLE
fix: Avoid creation of runtime directories in home

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -113,7 +113,7 @@
 
     - name: Make sure sshd runtime directory is present
       ansible.builtin.file:
-        path: "{{ __sshd_runtime_directory }}"
+        path: "/run/{{ __sshd_runtime_directory }}"
         state: directory
         owner: root
         group: root

--- a/tasks/install_service.yml
+++ b/tasks/install_service.yml
@@ -1,6 +1,6 @@
 ---
 - name: Install systemd service files
-  when: sshd_install_service | bool
+  when: sshd_install_service | bool and ansible_facts['service_mgr'] == 'systemd'
   block:
     - name: Install service unit file
       ansible.builtin.template:

--- a/templates/sshd.service.j2
+++ b/templates/sshd.service.j2
@@ -11,8 +11,10 @@ ExecReload=/bin/kill -HUP $MAINPID
 KillMode=process
 Restart=on-failure
 RestartPreventExitStatus=255
+{% if __sshd_runtime_directory is not none %}
 RuntimeDirectory={{ __sshd_runtime_directory }}
 RuntimeDirectoryMode={{ __sshd_runtime_directory_mode }}
+{% endif %}
 
 [Install]
 WantedBy=multi-user.target

--- a/templates/sshd@.service.j2
+++ b/templates/sshd@.service.j2
@@ -6,5 +6,7 @@ After=auditd.service
 [Service]
 ExecStart=-{{ sshd_binary }} -i -f {{ sshd_config_file }}
 StandardInput=socket
+{% if __sshd_runtime_directory is not none %}
 RuntimeDirectory={{ __sshd_runtime_directory }}
 RuntimeDirectoryMode={{ __sshd_runtime_directory_mode }}
+{% endif %}

--- a/tests/tests_runtime_directory.yml
+++ b/tests/tests_runtime_directory.yml
@@ -1,0 +1,52 @@
+---
+- name: Test runtime directory
+  hosts: all
+  vars:
+    __sshd_test_backup_files:
+      - /etc/ssh/sshd_config
+      - /etc/ssh/sshd_config.d/00-ansible_system_role.conf
+  tasks:
+    - name: Backup configuration files
+      ansible.builtin.include_tasks: tasks/backup.yml
+
+    - name: Configure sshd with default options
+      ansible.builtin.include_role:
+        name: ansible-sshd
+
+    - name: Verify the runtime diretory is created on Debian
+      tags: tests::verify
+      when:
+        - ansible_facts['os_family'] == "Debian"
+      block:
+        - name: Stat the default runtime directory
+          ansible.builtin.stat:
+            path: /run/sshd
+          register: run_stat
+
+        - name: Check the runtime directory is present
+          ansible.builtin.assert:
+            that:
+              - run_stat.stat.isdir
+              - run_stat.stat.mode == "0755"
+
+    - name: Verify the runtime diretory is not created in wrong places
+      tags: tests::verify
+      block:
+        - name: Stat the home directory for the runtime directory
+          ansible.builtin.stat:
+            path: ~/sshd
+          register: home_stat
+
+        - name: Stat the /run/~ for the runtime directory
+          ansible.builtin.stat:
+            path: /run/~
+          register: run_user_stat
+
+        - name: Check the wrong runtime directory is not present
+          ansible.builtin.assert:
+            that:
+              - not home_stat.stat.exists
+              - not run_user_stat.stat.exists
+
+    - name: "Restore configuration files"
+      ansible.builtin.include_tasks: tasks/restore.yml

--- a/tests/tests_runtime_directory.yml
+++ b/tests/tests_runtime_directory.yml
@@ -63,7 +63,7 @@
     - name: Verify the RuntimeDirectory is not placed into services when empty
       tags: tests::verify
       when:
-        - ansible_facts['os_family'] != "Debian"
+        - ansible_facts['os_family'] != "Debian" and ansible_facts['service_mgr'] == 'systemd'
       block:
         - name: Read the main service file
           ansible.builtin.slurp:

--- a/tests/tests_runtime_directory.yml
+++ b/tests/tests_runtime_directory.yml
@@ -5,13 +5,21 @@
     __sshd_test_backup_files:
       - /etc/ssh/sshd_config
       - /etc/ssh/sshd_config.d/00-ansible_system_role.conf
+      - /etc/systemd/system/sshd.service
+      - /etc/systemd/system/sshd@.service
+      - /etc/systemd/system/sshd.socket
+      - /etc/systemd/system/ssh.service
+      - /etc/systemd/system/ssh@.service
+      - /etc/systemd/system/ssh.socket
   tasks:
     - name: Backup configuration files
       ansible.builtin.include_tasks: tasks/backup.yml
 
-    - name: Configure sshd with default options
+    - name: Configure sshd with default options and install service
       ansible.builtin.include_role:
         name: ansible-sshd
+      vars:
+        sshd_install_service: true
 
     - name: Verify the runtime diretory is created on Debian
       tags: tests::verify
@@ -28,6 +36,57 @@
             that:
               - run_stat.stat.isdir
               - run_stat.stat.mode == "0755"
+
+        - name: Read the main service file
+          ansible.builtin.slurp:
+            src: /etc/systemd/system/ssh.service
+          register: service
+
+        - name: Read the instantiated service file
+          ansible.builtin.slurp:
+            src: /etc/systemd/system/ssh@.service
+          register: service_inst
+
+        - name: Read the main socket file
+          ansible.builtin.slurp:
+            src: /etc/systemd/system/ssh.socket
+          register: socket
+
+        - name: Check the runtime directory is in service files
+          ansible.builtin.assert:
+            that:
+              - '"RuntimeDirectory=sshd" in service.content | b64decode'
+              - '"RuntimeDirectoryMode=0755" in service.content | b64decode'
+              - '"RuntimeDirectory=sshd" in service_inst.content | b64decode'
+              - '"RuntimeDirectoryMode=0755" in service_inst.content | b64decode'
+
+    - name: Verify the RuntimeDirectory is not placed into services when empty
+      tags: tests::verify
+      when:
+        - ansible_facts['os_family'] != "Debian"
+      block:
+        - name: Read the main service file
+          ansible.builtin.slurp:
+            src: /etc/systemd/system/sshd.service
+          register: service
+
+        - name: Read the instantiated service file
+          ansible.builtin.slurp:
+            src: /etc/systemd/system/sshd@.service
+          register: service_inst
+
+        - name: Read the main socket file
+          ansible.builtin.slurp:
+            src: /etc/systemd/system/sshd.socket
+          register: socket
+
+        - name: Check the runtime directory is in service files
+          ansible.builtin.assert:
+            that:
+              - '"RuntimeDirectory=" not in service.content | b64decode'
+              - '"RuntimeDirectoryMode=" not in service.content | b64decode'
+              - '"RuntimeDirectory=" not in service_inst.content | b64decode'
+              - '"RuntimeDirectoryMode=" not in service_inst.content | b64decode'
 
     - name: Verify the runtime diretory is not created in wrong places
       tags: tests::verify


### PR DESCRIPTION
Enhancement: Avoid creation of runtime directory in home

Reason: The d6abe9c0325183180e6f83ba14c28781b9e6c6b9 changed the directories to be relative, but did not update tasks

Result: The playbook should create the runtime directory in the right place.

Issue Tracker Tickets (Jira or BZ if any): #264