### PR TITLE
tests: Ensure backup/restore preserves file attributes

### DIFF
--- a/tests/tasks/backup.yml
+++ b/tests/tasks/backup.yml
@@ -18,7 +18,7 @@
     set -eu
     if test -f {{ item }}; then
       mkdir -p {{ __sshd_test_backup.path }}/$(dirname {{ item }})
-      cp {{ item }} {{ __sshd_test_backup.path }}/$(dirname {{ item }})
+      cp -a {{ item }} {{ __sshd_test_backup.path }}/$(dirname {{ item }})
     fi
   changed_when: false
   loop: "{{ __sshd_test_backup_files | d([]) }}"

--- a/tests/tasks/restore.yml
+++ b/tests/tasks/restore.yml
@@ -6,7 +6,7 @@
       set -o pipefail
     fi
     if test -f {{ __sshd_test_backup.path }}/{{ item }}; then
-      cp {{ __sshd_test_backup.path }}/{{ item }} $(dirname {{ item }})
+      cp -a {{ __sshd_test_backup.path }}/{{ item }} $(dirname {{ item }})
     elif test -f {{ item }}; then
       rm {{ item }}
     fi


### PR DESCRIPTION
I noticed some test failures in tests that check ownership/permissions
of config files.  The tests were recently changed to reuse the same
VM, so I suspect config files were not being backed up/restored with
the correct file attributes.  Use `cp -a` to preserve all file
attributes.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
