### PR TITLE
ci: Use supported ansible-lint action; run ansible-lint against the collection

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,6 +1,11 @@
+---
 exclude_paths:
   - tests/roles/
   - .tox/
   - .markdownlint.yaml
 skip_list:
   - var-naming[no-role-prefix]
+mock_roles:
+  - willshersystems.sshd.ansible-sshd
+mock_modules:
+  - ansible.posix.mount

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -1,12 +1,38 @@
 name: Ansible Lint  # feel free to pick your own name
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
+
+env:
+  LSR_ROLE2COLL_NAMESPACE: willshersystems
+  LSR_ROLE2COLL_NAME: sshd
+
+permissions:
+  contents: read
 
 jobs:
   ansible-lint:
     runs-on: ubuntu-latest
     steps:
+      - name: Update pip, git
+        run: |
+          set -euxo pipefail
+          sudo apt update
+          sudo apt install -y git
       - name: checkout PR
         uses: actions/checkout@v4
-      - name: Lint Ansible playbook
-        uses: ansible/ansible-lint-action@main
+      - name: Install tox, tox-lsr
+        run: |
+          set -euxo pipefail
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.2.1"
+      - name: Convert role to collection format
+        run: |
+          set -euxo pipefail
+          TOXENV=collection lsr_ci_runtox
+          coll_dir=".tox/ansible_collections/$LSR_ROLE2COLL_NAMESPACE/$LSR_ROLE2COLL_NAME"
+          # ansible-lint action requires a .git directory???
+          # https://github.com/ansible/ansible-lint/blob/main/action.yml#L45
+          mkdir -p "$coll_dir/.git"
+      - name: Run ansible-lint
+        uses: ansible/ansible-lint@v6
+        with:
+          working_directory: .tox/ansible_collections/${{ env.LSR_ROLE2COLL_NAMESPACE }}/${{ env.LSR_ROLE2COLL_NAME }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vagrant
 tests/test.retry
+.tox

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,3 +1,4 @@
+---
 # Default state for all rules
 default: true
 

--- a/.ostree/get_ostree_data.sh
+++ b/.ostree/get_ostree_data.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/meta/make_ostree_packages_files
+++ b/meta/make_ostree_packages_files
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/tests/tests_all_options.yml
+++ b/tests/tests_all_options.yml
@@ -132,10 +132,8 @@
 
     - name: Verify the options are in the file
       ansible.builtin.assert:
-        that:
-          - "'{{ item }} yes' in config.content | b64decode "
-      loop:
-        "{{ sshd_options.stdout_lines }}"
+        that: item ~ " yes" in config.content | b64decode
+      loop: "{{ sshd_options.stdout_lines }}"
       when: not sshd_skip_test
 
     - name: Check generated files for ansible_managed, fingerprint

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,7 @@
+[lsr_config]
+lsr_enable = true
+
+[testenv]
+setenv =
+    LSR_ROLE2COLL_NAMESPACE = willshersystems
+    LSR_ROLE2COLL_NAME = sshd

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,3 +1,4 @@
+---
 __sshd_config_file: "/etc/ssh/sshd_config"
 __sshd_config_owner: "root"
 __sshd_config_group: "root"


### PR DESCRIPTION
The old ansible-community ansible-lint is deprecated.  There is a
new ansible-lint github action.

The latest Ansible repo gating tests run ansible-lint against
the collection format instead of against individual roles.
We have to convert the role to collection format before running
ansible-test.

This also requires tox-lsr 3.2.1

Role developers can run this locally using
`tox -e collection,ansible-lint-collection`
See https://github.com/linux-system-roles/tox-lsr/pull/125

Fix ansible-lint and ansible-test issues reported by the
latest 2.16 versions.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
