### PR TITLE
fix: Fix service files generated on EL7 and workaround the tests for containers

### DIFF
--- a/tasks/install_service.yml
+++ b/tasks/install_service.yml
@@ -1,6 +1,9 @@
 ---
 - name: Install systemd service files
-  when: sshd_install_service | bool and ansible_facts['service_mgr'] == 'systemd'
+  when:
+    - sshd_install_service | bool
+    - ansible_facts['service_mgr'] == 'systemd' or
+      (ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution_major_version'] == '7')
   block:
     - name: Install service unit file
       ansible.builtin.template:

--- a/templates/sshd.service.j2
+++ b/templates/sshd.service.j2
@@ -13,7 +13,7 @@ Documentation=man:sshd(8) man:sshd_config(5)
 [Service]
 Type=notify
 {% if __sshd_environment_file is string %}
-EnvironmentFile=-{{ __sshd_environment_file }}
+EnvironmentFile={{ __sshd_environment_file_mandatory | ternary('', '-')}}{{ __sshd_environment_file }}
 {% elif __sshd_environment_file is iterable %}
 {%   for file in __sshd_environment_file %}
 EnvironmentFile=-{{ file }}

--- a/tests/tests_systemd_services.yml
+++ b/tests/tests_systemd_services.yml
@@ -34,7 +34,8 @@
     - name: Read the service files and verify they are reasonable
       tags: tests::verify
       when:
-        - ansible_facts['service_mgr'] == 'systemd'
+        - ansible_facts['service_mgr'] == 'systemd' or
+          (ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution_major_version'] == '7')
       block:
         - name: Read the distribution service file
           ansible.builtin.slurp:
@@ -114,7 +115,8 @@
     - name: Read the instantiated service file and verify they are reasonable
       tags: tests::verify
       when:
-        - ansible_facts['service_mgr'] == 'systemd'
+        - ansible_facts['service_mgr'] == 'systemd' or
+          (ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution_major_version'] == '7')
         - ansible_facts['distribution'] != "Debian" or ansible_facts['distribution_major_version'] | int < 12
       block:
         - name: Read the distribution instantiated service file
@@ -153,7 +155,6 @@
           ansible.builtin.assert:
             that:
               - "' -f /etc/ssh/' in service_inst.content | b64decode"
-
 
     - name: "Restore configuration files"
       ansible.builtin.include_tasks: tasks/restore.yml

--- a/vars/RedHat_7.yml
+++ b/vars/RedHat_7.yml
@@ -33,6 +33,7 @@ __sshd_hostkeys_nofips:
   - /etc/ssh/ssh_host_ed25519_key
 
 __sshd_environment_file: /etc/sysconfig/sshd
+__sshd_environment_file_mandatory: true
 __sshd_environment_variable: $OPTIONS
 __sshd_service_after: sshd-keygen.service
 __sshd_service_wants: sshd-keygen.service

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -67,6 +67,7 @@ __sshd_supports_validate: true
 
 # The path to an environment file for the SSHD service
 __sshd_environment_file: ~
+__sshd_environment_file_mandatory: false
 
 # The variable name we are passing from the environment file as an argument to the sshd
 __sshd_environment_variable: $OPTIONS


### PR DESCRIPTION
Enhancement: The service files on EL7 are generated with original content.

Reason: The centos7 containers report `ansible_facts["service_mgr"] =  "sysvinit"` which lead to skipping this test in the upstream CI. The CentOS7 is also the only OS that defines the environment file as a mandatory (missing the `-` sign in front of the filename), which caused the downstream tests executed against VMs to fail. But only in the main `sshd.service`. The minus sign is present in the instantiated `sshd@.service` to add even more confusion

Result: The role should generate original service files.

Issue Tracker Tickets (Jira or BZ if any): -

The diff in the generated `sshd.service` file before this change should be limited to the following change:
```diff
-EnvironmentFile=/etc/sysconfig/sshd
+EnvironmentFile=-/etc/sysconfig/sshd
```