### PR TITLE
README.md typo in config word

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ This is useful mostly when generating configuration snippets to Include from
 drop-in directory (default in Fedora and RHEL9).
 
 When this path points to a drop-in directory (like
-`/etc/ssh/sshd_confg.d/00-custom.conf`), the main configuration file (defined
+`/etc/ssh/sshd_config.d/00-custom.conf`), the main configuration file (defined
 with the variable `sshd_main_config_file`) is checked to contain a proper
 `Include` directive.
 


### PR DESCRIPTION
Enhancement: typo

Reason: such folder does not exist in RHEL system

Result: typo

Issue Tracker Tickets (Jira or BZ if any):
