### PR TITLE
fix: Document and streamline the sshd_main_config_file

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,19 @@ When this path points to a drop-in directory (like
 with the variable `sshd_main_config_file`) is checked to contain a proper
 `Include` directive.
 
+#### sshd_main_config_file
+
+When the system is using drop-in directory, this option can be used to set
+a path to the main configuration file and let you configure only the drop-in
+configuration file using `sshd_config_file`. This is useful in cases when
+you need to configure second independent sshd service with different
+configuration file. This is also the file used in the service file.
+
+On systems without drop-in directory, it defaults to `None`. Otherwise it
+defaults to `/etc/ssh/sshd_config`. When the `sshd_config_file` is set
+outside of the drop in directory (its parent directory is not
+`sshd_main_config_file` ~ '.d'), this variable is ignored.
+
 #### sshd_config_namespace
 
 By default (*null*), the role defines whole content of the configuration file

--- a/meta/10_top.j2
+++ b/meta/10_top.j2
@@ -24,7 +24,7 @@
 {%   elif sshd[key] is defined %}
 {%     set value = sshd[key] %}
 {%   elif sshd_main_config_file is not none
-       and sshd_config_file | dirname != sshd_main_config_file | dirname %}
+        and sshd_config_file | dirname == sshd_main_config_file ~ '.d' %}
 {#     Do not use the defaults from main file to avoid recursion #}
 {%   elif __sshd_defaults[key] is defined and not sshd_skip_defaults %}
 {%     if key == 'HostKey' and __sshd_fips_mode %}

--- a/tasks/install_config.yml
+++ b/tasks/install_config.yml
@@ -6,7 +6,7 @@
     mode: "{{ sshd_drop_in_dir_mode }}"
   when:
     - sshd_main_config_file is not none
-    - sshd_config_file | dirname != sshd_main_config_file | dirname
+    - sshd_config_file | dirname == sshd_main_config_file ~ '.d'
 
 - name: Create the complete configuration file
   ansible.builtin.template:
@@ -46,4 +46,4 @@
   notify: reload_sshd
   when:
     - sshd_main_config_file is not none
-    - sshd_config_file | dirname != sshd_main_config_file | dirname
+    - sshd_config_file | dirname == sshd_main_config_file ~ '.d'

--- a/templates/sshd.service.j2
+++ b/templates/sshd.service.j2
@@ -20,7 +20,8 @@ EnvironmentFile=-{{ file }}
 {%   endfor %}
 {% endif %}
 ExecStartPre={{ sshd_binary }} -t
-ExecStart={{ sshd_binary }} -D {{ __sshd_environment_variable }} -f {% if sshd_main_config_file is not none %}
+ExecStart={{ sshd_binary }} -D {{ __sshd_environment_variable }} -f
+{%- if sshd_main_config_file is not none and sshd_config_file | dirname == sshd_main_config_file ~ '.d' %}
 {{- sshd_main_config_file }}
 {% else %}
 {{- sshd_config_file }}

--- a/templates/sshd@.service.j2
+++ b/templates/sshd@.service.j2
@@ -20,7 +20,8 @@ EnvironmentFile=-{{ __sshd_environment_file }}
 EnvironmentFile=-{{ file }}
 {%   endfor %}
 {% endif %}
-ExecStart=-{{ sshd_binary }} -i {{ __sshd_environment_variable }} -f {% if sshd_main_config_file is not none %}
+ExecStart=-{{ sshd_binary }} -i {{ __sshd_environment_variable }} -f
+{%- if sshd_main_config_file is not none and sshd_config_file | dirname == sshd_main_config_file ~ '.d' %}
 {{- sshd_main_config_file }}
 {% else %}
 {{- sshd_config_file }}

--- a/templates/sshd_config.j2
+++ b/templates/sshd_config.j2
@@ -26,7 +26,7 @@
 {%   elif sshd[key] is defined %}
 {%     set value = sshd[key] %}
 {%   elif sshd_main_config_file is not none
-       and sshd_config_file | dirname != sshd_main_config_file | dirname %}
+        and sshd_config_file | dirname == sshd_main_config_file ~ '.d' %}
 {#     Do not use the defaults from main file to avoid recursion #}
 {%   elif __sshd_defaults[key] is defined and not sshd_skip_defaults %}
 {%     if key == 'HostKey' and __sshd_fips_mode %}

--- a/templates/sshd_config_snippet.j2
+++ b/templates/sshd_config_snippet.j2
@@ -24,7 +24,7 @@
 {%   elif sshd[key] is defined %}
 {%     set value = sshd[key] %}
 {%   elif sshd_main_config_file is not none
-       and sshd_config_file | dirname != sshd_main_config_file | dirname %}
+        and sshd_config_file | dirname == sshd_main_config_file ~ '.d' %}
 {#     Do not use the defaults from main file to avoid recursion #}
 {%   elif __sshd_defaults[key] is defined and not sshd_skip_defaults %}
 {%     if key == 'HostKey' and __sshd_fips_mode %}

--- a/tests/tests_second_service.yml
+++ b/tests/tests_second_service.yml
@@ -1,0 +1,109 @@
+---
+- name: Test second sshd service
+  hosts: all
+  vars:
+    __sshd_test_backup_files:
+      - /etc/ssh/sshd_config
+      - /etc/ssh/sshd_config.d/00-ansible_system_role.conf
+      - /etc/ssh2/sshd_config
+      - /etc/systemd/system/sshd.service
+      - /etc/systemd/system/sshd@.service
+      - /etc/systemd/system/sshd.socket
+      - /etc/systemd/system/ssh.service
+      - /etc/systemd/system/ssh@.service
+      - /etc/systemd/system/ssh.socket
+      - /etc/systemd/system/sshd2.service
+      - /etc/systemd/system/sshd2@.service
+      - /etc/systemd/system/sshd2.socket
+  tasks:
+    - name: "Backup configuration files"
+      ansible.builtin.include_tasks: tasks/backup.yml
+
+    - name: Create ssh2 directory
+      ansible.builtin.file:
+        path: /etc/ssh2
+        state: directory
+        mode: '0755'
+
+    - name: Configure alternative sshd_config file
+      ansible.builtin.include_role:
+        name: ansible-sshd
+      vars:
+        sshd_service: sshd2
+        sshd_config_file: /etc/ssh2/sshd_config
+        sshd_install_service: true
+        sshd_manage_selinux: true
+        sshd:
+          Port: 2222
+          ForceCommand: echo "CONNECTED2"
+
+    - name: Verify the config options are correctly set
+      tags: tests::verify
+      block:
+        - name: Flush handlers
+          ansible.builtin.meta: flush_handlers
+
+        - name: Stat the parent directory
+          ansible.builtin.stat:
+            path: /etc/ssh2
+          register: parent_stat
+
+        - name: Print configuration file
+          ansible.builtin.slurp:
+            src: /etc/ssh2/sshd_config
+          register: config
+
+        - name: Check content of the created configuration file
+          ansible.builtin.assert:
+            that:
+              - "'Port 2222' in config.content | b64decode"
+              - "'ForceCommand echo' in config.content | b64decode"
+
+        - name: Check the parent directory has not changed to drop-in directory permissions
+          ansible.builtin.assert:
+            that:
+              - parent_stat.stat.exists
+              - parent_stat.stat.mode == '0755'
+
+    - name: Verify the service files are correct
+      tags: tests::verify
+      when:
+        - ansible_facts['service_mgr'] == 'systemd' or
+          (ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution_major_version'] == '7')
+      block:
+        - name: Read the created service file
+          ansible.builtin.slurp:
+            src: "/etc/systemd/system/sshd2.service"
+          register: service
+
+        - name: Read the created socket file
+          ansible.builtin.slurp:
+            src: "/etc/systemd/system/sshd2.socket"
+          register: socket
+
+        - name: Check content of the created service file
+          ansible.builtin.assert:
+            that:
+              - "' -f/etc/ssh/sshd_config' not in service.content | b64decode"
+              - "' -f/etc/ssh2/sshd_config' in service.content | b64decode"
+
+    - name: Verify the instantiated service file is correct
+      tags: tests::verify
+      when:
+        - ansible_facts['service_mgr'] == 'systemd' or
+          (ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution_major_version'] == '7')
+        - ansible_facts['distribution'] != "Debian" or ansible_facts['distribution_major_version'] | int < 12
+      block:
+        - name: Read the created instantiated service file
+          ansible.builtin.slurp:
+            src: "/etc/systemd/system/sshd2@.service"
+          register: service_inst
+
+        - name: Check content of the created service file
+          ansible.builtin.assert:
+            that:
+              - "' -f/etc/ssh/sshd_config' not in service_inst.content | b64decode"
+              - "' -f/etc/ssh2/sshd_config' in service_inst.content | b64decode"
+
+    - name: "Restore configuration files"
+      ansible.builtin.include_tasks: tasks/restore.yml

--- a/tests/tests_second_service_drop_in.yml
+++ b/tests/tests_second_service_drop_in.yml
@@ -1,0 +1,122 @@
+---
+- name: Test second sshd service with drop-in directory
+  hosts: all
+  vars:
+    __sshd_test_backup_files:
+      - /etc/ssh/sshd_config
+      - /etc/ssh/sshd_config.d/00-ansible_system_role.conf
+      - /etc/ssh2/sshd_config
+      - /etc/sshd/sshd_config.d/04-ansible.conf
+      - /etc/systemd/system/sshd2.service
+      - /etc/systemd/system/sshd2@.service
+      - /etc/systemd/system/sshd2.socket
+  tasks:
+    - name: "Backup configuration files"
+      ansible.builtin.include_tasks: tasks/backup.yml
+
+    - name: Run the test
+      when:
+        - (ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution_major_version'] | int > 8) or
+          (ansible_facts['distribution'] == 'Ubuntu' and ansible_facts['distribution_major_version'] | int >= 20)
+      block:
+        - name: Create ssh2 directory
+          ansible.builtin.file:
+            path: /etc/ssh2
+            state: directory
+            mode: '0755'
+
+        - name: Create sshd_config file
+          ansible.builtin.file:
+            path: /etc/ssh2/sshd_config
+            state: touch
+            mode: '0600'
+
+        - name: Configure alternative sshd_config file
+          ansible.builtin.include_role:
+            name: ansible-sshd
+          vars:
+            sshd_service: sshd2
+            sshd_main_config_file: /etc/ssh2/sshd_config
+            sshd_config_file: /etc/ssh2/sshd_config.d/04-ansible.conf
+            sshd_install_service: true
+            sshd_manage_selinux: true
+            sshd:
+              Port: 2222
+              ForceCommand: echo "CONNECTED2"
+
+        - name: Verify the config options are correctly set
+          tags: tests::verify
+          block:
+            - name: Flush handlers
+              ansible.builtin.meta: flush_handlers
+
+            - name: Stat the parent directory
+              ansible.builtin.stat:
+                path: /etc/ssh2
+              register: parent_stat
+
+            - name: Print the main configuration file
+              ansible.builtin.slurp:
+                src: /etc/ssh2/sshd_config
+              register: config
+
+            - name: Print the drop-in configuration file
+              ansible.builtin.slurp:
+                src: /etc/ssh2/sshd_config.d/04-ansible.conf
+              register: config_drop_in
+
+            - name: Check content of the created configuration file
+              ansible.builtin.assert:
+                that:
+                  - "'Port 2222' in config_drop_in.content | b64decode"
+                  - "'ForceCommand echo' in config_drop_in.content | b64decode"
+
+            - name: Check Include is present in the main configuration file
+              ansible.builtin.assert:
+                that:
+                  - "'Include' in config.content | b64decode"
+
+            - name: Check the parent directory has not changed to drop-in directory permissions
+              ansible.builtin.assert:
+                that:
+                  - parent_stat.stat.exists
+                  - parent_stat.stat.mode == '0755'
+
+        - name: Verify the service files are correct
+          tags: tests::verify
+          block:
+            - name: Read the created service file
+              ansible.builtin.slurp:
+                src: "/etc/systemd/system/sshd2.service"
+              register: service
+
+            - name: Read the created socket file
+              ansible.builtin.slurp:
+                src: "/etc/systemd/system/sshd2.socket"
+              register: socket
+
+            - name: Check content of the created service file
+              ansible.builtin.assert:
+                that:
+                  - "' -f/etc/ssh/sshd_config' not in service.content | b64decode"
+                  - "' -f/etc/ssh2/sshd_config' in service.content | b64decode"
+
+        - name: Verify the instantiated service file is correct
+          tags: tests::verify
+          when:
+            - ansible_facts['service_mgr'] == 'systemd'
+            - ansible_facts['distribution'] != "Debian" or ansible_facts['distribution_major_version'] | int < 12
+          block:
+            - name: Read the created instantiated service file
+              ansible.builtin.slurp:
+                src: "/etc/systemd/system/sshd2@.service"
+              register: service_inst
+
+            - name: Check content of the created service file
+              ansible.builtin.assert:
+                that:
+                  - "' -f/etc/ssh/sshd_config' not in service_inst.content | b64decode"
+                  - "' -f/etc/ssh2/sshd_config' in service_inst.content | b64decode"
+
+    - name: "Restore configuration files"
+      ansible.builtin.include_tasks: tasks/restore.yml

--- a/tests/tests_systemd_services.yml
+++ b/tests/tests_systemd_services.yml
@@ -84,7 +84,7 @@
         - name: Verify the ExecStart line contains the configuration file
           ansible.builtin.assert:
             that:
-              - "' -f /etc/ssh/' in service.content | b64decode"
+              - "' -f/etc/ssh/' in service.content | b64decode"
 
         - name: Decode socket file
           ansible.builtin.set_fact:
@@ -154,7 +154,7 @@
         - name: Verify the ExecStart line contains the configuration file
           ansible.builtin.assert:
             that:
-              - "' -f /etc/ssh/' in service_inst.content | b64decode"
+              - "' -f/etc/ssh/' in service_inst.content | b64decode"
 
     - name: "Restore configuration files"
       ansible.builtin.include_tasks: tasks/restore.yml


### PR DESCRIPTION
The option was introduced in f6ae2094fe23eed94ce64eee1d0f5f1109dfe1da without documentation and intended use. The recent change f6ae2094fe23eed94ce64eee1d0f5f1109dfe1da propagated this option to the generated service files, which is resulting in unexpected results, when a user decided to set only `sshd_config_file` for the second sshd service such as:
 * the service file points to the system-wide configuration file
 * the system-wide configuration file will get include directive pointing to the directory of the second configuration file

This is an attempt to fix this by introducing some heuristics to guess if the user wants to set up second drop-in directory (ending with .d) or create a standalone configuration file.

Issue Tracker Tickets (Jira or BZ if any): https://issues.redhat.com/browse/RHEL-29309 #280
