### PR TITLE
fix: add support for EL10

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -35,4 +35,4 @@ jobs:
       - name: Run ansible-lint
         uses: ansible/ansible-lint@v24
         with:
-          working_directory: .tox/ansible_collections/${{ env.LSR_ROLE2COLL_NAMESPACE }}/${{ env.LSR_ROLE2COLL_NAME }}
+          working_directory: ${{ github.workspace }}/.tox/ansible_collections/${{ env.LSR_ROLE2COLL_NAMESPACE }}/${{ env.LSR_ROLE2COLL_NAME }}

--- a/.ostree/packages-runtime-CentOS-10.txt
+++ b/.ostree/packages-runtime-CentOS-10.txt
@@ -1,0 +1,1 @@
+packages-runtime-RedHat-10.txt

--- a/.ostree/packages-runtime-CentOS-6.txt
+++ b/.ostree/packages-runtime-CentOS-6.txt
@@ -1,2 +1,1 @@
-openssh
-openssh-server
+packages-runtime-RedHat-6.txt

--- a/.ostree/packages-runtime-CentOS-7.txt
+++ b/.ostree/packages-runtime-CentOS-7.txt
@@ -1,2 +1,1 @@
-openssh
-openssh-server
+packages-runtime-RedHat-7.txt

--- a/.ostree/packages-runtime-CentOS-8.txt
+++ b/.ostree/packages-runtime-CentOS-8.txt
@@ -1,2 +1,1 @@
-openssh
-openssh-server
+packages-runtime-RedHat-8.txt

--- a/.ostree/packages-runtime-CentOS-9.txt
+++ b/.ostree/packages-runtime-CentOS-9.txt
@@ -1,2 +1,1 @@
-openssh
-openssh-server
+packages-runtime-RedHat-9.txt

--- a/.ostree/packages-runtime-RedHat-10.txt
+++ b/.ostree/packages-runtime-RedHat-10.txt
@@ -1,0 +1,2 @@
+openssh
+openssh-server

--- a/.ostree/packages-testing-CentOS.txt
+++ b/.ostree/packages-testing-CentOS.txt
@@ -1,1 +1,1 @@
-man-db
+packages-testing-RedHat.txt

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Tested on:
   * [![Run tests on Ubuntu latest](https://github.com/willshersystems/ansible-sshd/actions/workflows/ansible-ubuntu.yml/badge.svg)](https://github.com/willshersystems/ansible-sshd/actions/workflows/ansible-ubuntu.yml)
 * Debian wheezy, jessie, stretch, buster, bullseye, bookworm
   * [![Run tests on Debian](https://github.com/willshersystems/ansible-sshd/actions/workflows/ansible-debian-check.yml/badge.svg)](https://github.com/willshersystems/ansible-sshd/actions/workflows/ansible-debian-check.yml)
-* EL 6, 7, 8, 9 derived distributions
+* EL 6, 7, 8, 9, 10 derived distributions
   * [![Run tests on CentOS](https://github.com/willshersystems/ansible-sshd/actions/workflows/ansible-centos-check.yml/badge.svg)](https://github.com/willshersystems/ansible-sshd/actions/workflows/ansible-centos-check.yml)
 * All Fedora
   * [![Run tests on Fedora latest](https://github.com/willshersystems/ansible-sshd/actions/workflows/ansible-fedora.yml/badge.svg)](https://github.com/willshersystems/ansible-sshd/actions/workflows/ansible-fedora.yml)

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -58,7 +58,13 @@ galaxy_info:
     - debian
     - centos
     - redhat
+    - fedora
     - freebsd
     - openbsd
     - aix
+    - el6
+    - el7
+    - el8
+    - el9
+    - el10
 dependencies: []

--- a/vars/RedHat_10.yml
+++ b/vars/RedHat_10.yml
@@ -1,0 +1,33 @@
+---
+__sshd_os_supported: true
+
+__sshd_packages:
+  - openssh
+  - openssh-server
+__sshd_sftp_server: /usr/libexec/openssh/sftp-server
+# RHEL 10 ships with drop-in directory support so we touch
+# just included file with highest priority by default
+__sshd_config_file: /etc/ssh/sshd_config.d/00-ansible_system_role.conf
+# the defaults here represent the defaults shipped in the main sshd_config
+__sshd_defaults:
+  Include: /etc/ssh/sshd_config.d/*.conf
+  AuthorizedKeysFile: .ssh/authorized_keys
+  Subsystem: "sftp {{ __sshd_sftp_server }}"
+
+__sshd_verify_hostkeys_default:
+  - /etc/ssh/ssh_host_rsa_key
+  - /etc/ssh/ssh_host_ecdsa_key
+  - /etc/ssh/ssh_host_ed25519_key
+__sshd_hostkeys_nofips:
+  - /etc/ssh/ssh_host_ed25519_key
+
+__sshd_drop_in_dir_mode: '0700'
+__sshd_main_config_file: /etc/ssh/sshd_config
+
+__sshd_environment_file: /etc/sysconfig/sshd
+__sshd_environment_variable: $OPTIONS
+__sshd_service_after: sshd-keygen.target
+__sshd_service_wants:
+  - sshd-keygen.target
+  - ssh-host-keys-migration.service
+__sshd_service_restart_timeout: 42s


### PR DESCRIPTION
According to the Ansible team, support for listing platforms in
role `meta/main.yml` files is being removed.
Instead, they recommend using `galaxy_tags`

https://github.com/ansible/ansible/blob/stable-2.17/changelogs/CHANGELOG-v2.17.rst
"Remove the galaxy_info field platforms from the role templates"
https://github.com/ansible/ansible/issues/82453

For each version listed under `platforms.EL` - add a tag like `elN`.

Q: Why not use a delimiter between the platform and the version e.g. `el-10`?

This is not allowed by ansible-lint:

```
meta-no-tags: Tags must contain lowercase letters and digits only., invalid: 'el-10'
meta/main.yml:1
```

So we cannot use uppercase letters either.

Q: Why not use our own meta/main.yml field?

No other fields are allowed by ansible-lint:

```
syntax-check[specific]: 'myfield' is not a valid attribute for a RoleMetadata
```

Q: Why not use some other field?

There are no other applicable or suitable fields.

Q: What happens when we want to support versions like `N.M`?

Use the word "dot" instead of "." e.g. `el10dot3`.
Similarly - use "dash" instead of "-".

We do not need tags such as `fedoraall`.
The `fedora` tag implies that the role works on all supported versions of fedora.
Otherwise, use tags such as `fedora40` if the role only supports specific versions.

In addition - for roles that have different variable files for EL9, create
the corresponding EL10 files, and update the variables for EL10.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
