### PR TITLE
feat: Add new configuration options from OpenSSH 9.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,4 +486,4 @@ Matt Willsher <matt@willsher.systems>
 
 Jakub Jelen <jjelen@redhat.com>
 
-&copy; 2020 - 2022 Red Hat, Inc.
+&copy; 2020 - 2024 Red Hat, Inc.

--- a/meta/options_body
+++ b/meta/options_body
@@ -73,6 +73,7 @@ MaxSessions
 MaxStartups
 ModuliFile
 NoneEnabled
+PAMServiceName
 PasswordAuthentication
 PermitEmptyPasswords
 PermitListen
@@ -82,6 +83,8 @@ PermitTTY
 PermitTunnel
 PermitUserEnvironment
 PermitUserRC
+PerSourcePenalties
+PerSourcePenaltyExemptList
 PerSourceMaxStartups
 PerSourceNetBlockSize
 PidFile
@@ -102,6 +105,7 @@ SecurityKeyProvider
 SetEnv
 ServerKeyBits
 ShowPatchLevel
+SshdSessionPath
 StreamLocalBindMask
 StreamLocalBindUnlink
 StrictModes

--- a/meta/options_match
+++ b/meta/options_match
@@ -36,6 +36,7 @@ KerberosAuthentication
 LogLevel
 MaxAuthTries
 MaxSessions
+PAMServiceName
 PasswordAuthentication
 PermitEmptyPasswords
 PermitListen

--- a/templates/sshd_config.j2
+++ b/templates/sshd_config.j2
@@ -82,6 +82,7 @@ Match {{ match["Condition"] }}
 {{       render_option("LogLevel",match["LogLevel"],true) -}}
 {{       render_option("MaxAuthTries",match["MaxAuthTries"],true) -}}
 {{       render_option("MaxSessions",match["MaxSessions"],true) -}}
+{{       render_option("PAMServiceName",match["PAMServiceName"],true) -}}
 {{       render_option("PasswordAuthentication",match["PasswordAuthentication"],true) -}}
 {{       render_option("PermitEmptyPasswords",match["PermitEmptyPasswords"],true) -}}
 {{       render_option("PermitListen",match["PermitListen"],true) -}}
@@ -197,6 +198,7 @@ Match {{ match["Condition"] }}
 {{ body_option("MaxStartups",sshd_MaxStartups) -}}
 {{ body_option("ModuliFile",sshd_ModuliFile) -}}
 {{ body_option("NoneEnabled",sshd_NoneEnabled) -}}
+{{ body_option("PAMServiceName",sshd_PAMServiceName) -}}
 {{ body_option("PasswordAuthentication",sshd_PasswordAuthentication) -}}
 {{ body_option("PermitEmptyPasswords",sshd_PermitEmptyPasswords) -}}
 {{ body_option("PermitListen",sshd_PermitListen) -}}
@@ -206,6 +208,8 @@ Match {{ match["Condition"] }}
 {{ body_option("PermitTunnel",sshd_PermitTunnel) -}}
 {{ body_option("PermitUserEnvironment",sshd_PermitUserEnvironment) -}}
 {{ body_option("PermitUserRC",sshd_PermitUserRC) -}}
+{{ body_option("PerSourcePenalties",sshd_PerSourcePenalties) -}}
+{{ body_option("PerSourcePenaltyExemptList",sshd_PerSourcePenaltyExemptList) -}}
 {{ body_option("PerSourceMaxStartups",sshd_PerSourceMaxStartups) -}}
 {{ body_option("PerSourceNetBlockSize",sshd_PerSourceNetBlockSize) -}}
 {{ body_option("PidFile",sshd_PidFile) -}}
@@ -226,6 +230,7 @@ Match {{ match["Condition"] }}
 {{ body_option("SetEnv",sshd_SetEnv) -}}
 {{ body_option("ServerKeyBits",sshd_ServerKeyBits) -}}
 {{ body_option("ShowPatchLevel",sshd_ShowPatchLevel) -}}
+{{ body_option("SshdSessionPath",sshd_SshdSessionPath) -}}
 {{ body_option("StreamLocalBindMask",sshd_StreamLocalBindMask) -}}
 {{ body_option("StreamLocalBindUnlink",sshd_StreamLocalBindUnlink) -}}
 {{ body_option("StrictModes",sshd_StrictModes) -}}

--- a/templates/sshd_config_snippet.j2
+++ b/templates/sshd_config_snippet.j2
@@ -80,6 +80,7 @@ Match {{ match["Condition"] }}
 {{       render_option("LogLevel",match["LogLevel"],true) -}}
 {{       render_option("MaxAuthTries",match["MaxAuthTries"],true) -}}
 {{       render_option("MaxSessions",match["MaxSessions"],true) -}}
+{{       render_option("PAMServiceName",match["PAMServiceName"],true) -}}
 {{       render_option("PasswordAuthentication",match["PasswordAuthentication"],true) -}}
 {{       render_option("PermitEmptyPasswords",match["PermitEmptyPasswords"],true) -}}
 {{       render_option("PermitListen",match["PermitListen"],true) -}}
@@ -195,6 +196,7 @@ Match {{ match["Condition"] }}
 {{ body_option("MaxStartups",sshd_MaxStartups) -}}
 {{ body_option("ModuliFile",sshd_ModuliFile) -}}
 {{ body_option("NoneEnabled",sshd_NoneEnabled) -}}
+{{ body_option("PAMServiceName",sshd_PAMServiceName) -}}
 {{ body_option("PasswordAuthentication",sshd_PasswordAuthentication) -}}
 {{ body_option("PermitEmptyPasswords",sshd_PermitEmptyPasswords) -}}
 {{ body_option("PermitListen",sshd_PermitListen) -}}
@@ -204,6 +206,8 @@ Match {{ match["Condition"] }}
 {{ body_option("PermitTunnel",sshd_PermitTunnel) -}}
 {{ body_option("PermitUserEnvironment",sshd_PermitUserEnvironment) -}}
 {{ body_option("PermitUserRC",sshd_PermitUserRC) -}}
+{{ body_option("PerSourcePenalties",sshd_PerSourcePenalties) -}}
+{{ body_option("PerSourcePenaltyExemptList",sshd_PerSourcePenaltyExemptList) -}}
 {{ body_option("PerSourceMaxStartups",sshd_PerSourceMaxStartups) -}}
 {{ body_option("PerSourceNetBlockSize",sshd_PerSourceNetBlockSize) -}}
 {{ body_option("PidFile",sshd_PidFile) -}}
@@ -224,6 +228,7 @@ Match {{ match["Condition"] }}
 {{ body_option("SetEnv",sshd_SetEnv) -}}
 {{ body_option("ServerKeyBits",sshd_ServerKeyBits) -}}
 {{ body_option("ShowPatchLevel",sshd_ShowPatchLevel) -}}
+{{ body_option("SshdSessionPath",sshd_SshdSessionPath) -}}
 {{ body_option("StreamLocalBindMask",sshd_StreamLocalBindMask) -}}
 {{ body_option("StreamLocalBindUnlink",sshd_StreamLocalBindUnlink) -}}
 {{ body_option("StrictModes",sshd_StrictModes) -}}


### PR DESCRIPTION
Enhancement: Add new configuration options from OpenSSH 9.8

Reason: The CentOS 10 Stream and Fedora rawhide are getting updated to new OpenSSH version

Result: The new configuration options are usable through this role

Issue Tracker Tickets (Jira or BZ if any):
