### PR TITLE
fix: Reload the service when needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ Ubuntu. This is not the default assigned by this module - it will set
 via simple password. If you need this functionality, be sure to set
 `sshd_PermitRootLogin yes` for those hosts.
 
+**NOTE** The sshd service is reloaded/restarted automatically, only if the role is
+invoked using `roles` keyword. Using `include_role` won't trigger handlers
+as described in
+[official documentation](https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_handlers.html#controlling-when-handlers-run).
+If you need to invoke the handlers in this case, use `meta: flush_handlers`.
+
 ## Requirements
 
 Tested on:

--- a/README.md
+++ b/README.md
@@ -96,6 +96,14 @@ changed configuration. Defaults to the same value as `sshd_manage_service`.
 (Except on AIX, where `sshd_manage_service` is default *false*, but
 `sshd_allow_reload` is default *true*)
 
+#### sshd_allow_restart
+
+Some changes, for example of the sysconfig and environment files require the full
+restart of the service. If set to *false*, a restart of sshd won't happen on these
+changes. This can help with troubleshooting. You'll need to manually restart sshd
+if you want to apply the changed configuration. Defaults to the same value as
+`sshd_manage_service`.
+
 #### sshd_install_service
 
 If set to *true*, the role will install service files for the ssh service.

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ via simple password. If you need this functionality, be sure to set
 
 **NOTE** The sshd service is reloaded/restarted automatically, only if the role is
 invoked using `roles` keyword. Using `include_role` won't trigger handlers
-as described in
-[official documentation](https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_handlers.html#controlling-when-handlers-run).
+as described in the Ansible ['taskify includes' proposal](https://github.com/ansible/proposals/issues/136). To work around this, call `meta: flush_handlers` as detailed in the
+[official Ansible documentation](https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_handlers.html#controlling-when-handlers-run).
 If you need to invoke the handlers in this case, use `meta: flush_handlers`.
 
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -92,17 +92,16 @@ for AIX)
 
 If set to *false*, a reload of sshd won't happen on change. This can help with
 troubleshooting. You'll need to manually reload sshd if you want to apply the
-changed configuration. Defaults to the same value as `sshd_manage_service`.
-(Except on AIX, where `sshd_manage_service` is default *false*, but
-`sshd_allow_reload` is default *true*)
+changed configuration. Defaults to *true*.
 
 #### sshd_allow_restart
 
 Some changes, for example of the sysconfig and environment files require the full
 restart of the service. If set to *false*, a restart of sshd won't happen on these
 changes. This can help with troubleshooting. You'll need to manually restart sshd
-if you want to apply the changed configuration. Defaults to the same value as
-`sshd_manage_service`.
+if you want to apply the changed configuration. Defaults to *true* (except on AIX
+where the reload is handled by specific restart command and this option does not
+have any effect).
 
 #### sshd_install_service
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,6 +13,9 @@ sshd_manage_service: true
 # If the below is false, don't reload the ssh daemon on change
 sshd_allow_reload: true
 
+# If the below is false, don't restart the ssh daemon on change that requires restart
+sshd_allow_restart: true
+
 # If the below is true, also install service files from the templates pointed
 # to by the `sshd_service_template_*` variables
 sshd_install_service: false

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -12,6 +12,18 @@
     - ansible_facts['os_family'] != 'OpenWrt'
   listen: Reload_sshd
 
+- name: Restart the SSH service
+  ansible.builtin.service:
+    name: "{{ sshd_service }}"
+    state: restarted
+  when:
+    - sshd_allow_restart|bool
+    - ansible_facts['virtualization_type'] | default(None) not in __sshd_skip_virt_env
+    - ansible_connection != 'chroot'
+    - ansible_facts['os_family'] != 'AIX'
+    - ansible_facts['os_family'] != 'OpenWrt'
+  listen: Restart_sshd
+
 # sshd on AIX cannot be 'reloaded', it must be Stopped+Started.
 # It's dangerous to do this in two tasks.. you're stopping SSH and then trying to SSH back in to start it.
 # Instead, use a dirty shell script:

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -10,7 +10,7 @@
     - ansible_connection != 'chroot'
     - ansible_facts['os_family'] != 'AIX'
     - ansible_facts['os_family'] != 'OpenWrt'
-  listen: Reload_sshd
+  listen: sshd_reload
 
 - name: Restart the SSH service
   ansible.builtin.service:
@@ -22,7 +22,7 @@
     - ansible_connection != 'chroot'
     - ansible_facts['os_family'] != 'AIX'
     - ansible_facts['os_family'] != 'OpenWrt'
-  listen: Restart_sshd
+  listen: sshd_restart
 
 # sshd on AIX cannot be 'reloaded', it must be Stopped+Started.
 # It's dangerous to do this in two tasks.. you're stopping SSH and then trying to SSH back in to start it.
@@ -37,7 +37,7 @@
     stopsrc -s sshd
     until $(lssrc -s sshd | grep -q inoperative); do sleep 1; done
     startsrc -s sshd
-  listen: Reload_sshd
+  listen: sshd_reload
   changed_when: false
   when:
     - sshd_allow_reload|bool
@@ -51,4 +51,4 @@
   when:
     - sshd_allow_reload|bool
     - ansible_facts['os_family'] == 'OpenWrt'
-  listen: Reload_sshd
+  listen: sshd_reload

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -25,7 +25,7 @@
   when:
     - sshd_sysconfig | bool
     - __sshd_sysconfig_supports_use_strong_rng or __sshd_sysconfig_supports_crypto_policy
-  notify: Reload_sshd
+  notify: Restart_sshd
 
 - name: Check FIPS mode
   ansible.builtin.include_tasks: check_fips.yml

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -25,7 +25,7 @@
   when:
     - sshd_sysconfig | bool
     - __sshd_sysconfig_supports_use_strong_rng or __sshd_sysconfig_supports_crypto_policy
-  notify: Restart_sshd
+  notify: sshd_restart
 
 - name: Check FIPS mode
   ansible.builtin.include_tasks: check_fips.yml

--- a/tasks/install_config.yml
+++ b/tasks/install_config.yml
@@ -24,7 +24,7 @@
         {{ sshd_binary | quote }} -t -f %s
       {% endif %}
     backup: "{{ sshd_backup }}"
-  notify: Reload_sshd
+  notify: sshd_reload
 
 - name: Make sure the include path is present in the main sshd_config
   ansible.builtin.lineinfile:
@@ -43,7 +43,7 @@
         {{ sshd_binary | quote }} -t -f %s
       {% endif %}
     backup: "{{ sshd_backup }}"
-  notify: Reload_sshd
+  notify: sshd_reload
   when:
     - sshd_main_config_file is not none
     - sshd_config_file | dirname == sshd_main_config_file ~ '.d'

--- a/tasks/install_namespace.yml
+++ b/tasks/install_namespace.yml
@@ -21,4 +21,4 @@
         {{ sshd_binary | quote }} -t -f %s
       {% endif %}
     backup: "{{ sshd_backup }}"
-  notify: Reload_sshd
+  notify: sshd_reload

--- a/tasks/install_service.yml
+++ b/tasks/install_service.yml
@@ -12,7 +12,7 @@
         owner: root
         group: root
         mode: "0644"
-      notify: Reload_sshd
+      notify: sshd_reload
 
     - name: Install instanced service unit file
       ansible.builtin.template:
@@ -21,7 +21,7 @@
         owner: root
         group: root
         mode: "0644"
-      notify: Reload_sshd
+      notify: sshd_reload
       when:
         - __sshd_socket_accept | bool
 
@@ -32,7 +32,7 @@
         owner: root
         group: root
         mode: "0644"
-      notify: Reload_sshd
+      notify: sshd_reload
 
 - name: Service enabled and running
   ansible.builtin.service:

--- a/vars/AIX.yml
+++ b/vars/AIX.yml
@@ -12,3 +12,4 @@ __sshd_os_supported: true
 sshd_install_service: false
 sshd_manage_service: false
 sshd_allow_reload: true
+sshd_allow_restart: false


### PR DESCRIPTION
The change of sysconfig requires the full restart instead of only reload.

I did not figure out a better way to avoid doing both in this case, so comments and suggestions welcomed.

Fixes: #302