### PR TITLE
feat: Add new options from OpenSSH 10.0

### DIFF
--- a/meta/options_body
+++ b/meta/options_body
@@ -106,6 +106,7 @@ SecurityKeyProvider
 SetEnv
 ServerKeyBits
 ShowPatchLevel
+SshdAuthPath
 SshdSessionPath
 StreamLocalBindMask
 StreamLocalBindUnlink

--- a/templates/sshd_config.j2
+++ b/templates/sshd_config.j2
@@ -232,6 +232,7 @@ Match {{ match["Condition"] }}
 {{ body_option("SetEnv",sshd_SetEnv) -}}
 {{ body_option("ServerKeyBits",sshd_ServerKeyBits) -}}
 {{ body_option("ShowPatchLevel",sshd_ShowPatchLevel) -}}
+{{ body_option("SshdAuthPath",sshd_SshdAuthPath) -}}
 {{ body_option("SshdSessionPath",sshd_SshdSessionPath) -}}
 {{ body_option("StreamLocalBindMask",sshd_StreamLocalBindMask) -}}
 {{ body_option("StreamLocalBindUnlink",sshd_StreamLocalBindUnlink) -}}

--- a/templates/sshd_config_snippet.j2
+++ b/templates/sshd_config_snippet.j2
@@ -230,6 +230,7 @@ Match {{ match["Condition"] }}
 {{ body_option("SetEnv",sshd_SetEnv) -}}
 {{ body_option("ServerKeyBits",sshd_ServerKeyBits) -}}
 {{ body_option("ShowPatchLevel",sshd_ShowPatchLevel) -}}
+{{ body_option("SshdAuthPath",sshd_SshdAuthPath) -}}
 {{ body_option("SshdSessionPath",sshd_SshdSessionPath) -}}
 {{ body_option("StreamLocalBindMask",sshd_StreamLocalBindMask) -}}
 {{ body_option("StreamLocalBindUnlink",sshd_StreamLocalBindUnlink) -}}


### PR DESCRIPTION
Enhancement: Add new options from OpenSSH 10

Reason: The OpenSSH 10.0 provides a new configuration option `SshdAuthPath`.

Result: Users can configure openssh with the new configuration option

Issue Tracker Tickets (Jira or BZ if any): - 
