### PR TITLE
feat: add Debian 13 support

### DIFF
--- a/.github/workflows/ansible-debian-check.yml
+++ b/.github/workflows/ansible-debian-check.yml
@@ -10,7 +10,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: ansible check with debian trixie (13)
-        uses: roles-ansible/check-ansible-debian-latest-action@v1.4
+        uses: domrim/check-ansible-debian-trixie-action@v1
         with:
           group: local
           hosts: localhost

--- a/.github/workflows/ansible-debian-check.yml
+++ b/.github/workflows/ansible-debian-check.yml
@@ -3,6 +3,20 @@ name: Run tests on Debian
 on: [push, pull_request]
 
 jobs:
+  debian-trixie:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout PR
+        uses: actions/checkout@v4
+
+      - name: ansible check with debian trixie (13)
+        uses: roles-ansible/check-ansible-debian-latest-action@v1.4
+        with:
+          group: local
+          hosts: localhost
+          targets: "tests/tests_*.yml"
+          requirements: tests/requirements.yml
+
   debian-bookworm:
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Tested on:
 
 * Ubuntu precise, trusty, xenial, bionic, focal, jammy, noble
   * [![Run tests on Ubuntu latest](https://github.com/willshersystems/ansible-sshd/actions/workflows/ansible-ubuntu.yml/badge.svg)](https://github.com/willshersystems/ansible-sshd/actions/workflows/ansible-ubuntu.yml)
-* Debian wheezy, jessie, stretch, buster, bullseye, bookworm
+* Debian 11 (Bullseye), 12 (Bookworm), 13 (Trixie)
   * [![Run tests on Debian](https://github.com/willshersystems/ansible-sshd/actions/workflows/ansible-debian-check.yml/badge.svg)](https://github.com/willshersystems/ansible-sshd/actions/workflows/ansible-debian-check.yml)
 * EL 6, 7, 8, 9, 10 derived distributions
   * [![Run tests on CentOS](https://github.com/willshersystems/ansible-sshd/actions/workflows/ansible-centos-check.yml/badge.svg)](https://github.com/willshersystems/ansible-sshd/actions/workflows/ansible-centos-check.yml)

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -16,6 +16,7 @@ galaxy_info:
         - buster
         - bullseye
         - bookworm
+        - trixie
     - name: Ubuntu
       versions:
         - precise

--- a/tests/tests_all_options.yml
+++ b/tests/tests_all_options.yml
@@ -95,7 +95,7 @@
           | grep -o '^\(     \|       \)[A-Z][A-Za-z0-9]*\(.\|  \)' \
           | grep -v "[A-Za-z0-9] $" | grep -v "[^A-Za-z0-9 ]$" \
           | awk '{ print $1 }' \
-          | grep -v '^$' | grep -v "^\(Match\|OpenSSH\|The\|Arguments\|Theo\|Tatu\|Aaron\|Each\)$"
+          | grep -v '^$' | grep -v "^\(Match\|OpenSSH\|The\|Arguments\|Theo\|Tatu\|Aaron\|Each\|Note\)$"
       args:
         executable: /bin/bash
       register: sshd_options

--- a/vars/Debian_13.yml
+++ b/vars/Debian_13.yml
@@ -1,0 +1,23 @@
+---
+__sshd_service: ssh
+__sshd_packages:
+  - openssh-server
+  - openssh-sftp-server
+__sshd_config_mode: "0644"
+__sshd_defaults:
+  Include: /etc/ssh/sshd_config.d/*.conf
+  KbdInteractiveAuthentication: false
+  UsePAM: true
+  X11Forwarding: true
+  PrintMotd: false
+  AcceptEnv: LANG LC_*
+  Subsystem: "sftp {{ __sshd_sftp_server }}"
+__sshd_os_supported: true
+__sshd_runtime_directory: sshd
+
+__sshd_environment_file: /etc/default/ssh
+__sshd_environment_variable:
+  - SSHD_OPTS
+__sshd_service_after: auditd.service
+__sshd_service_alias: sshd
+__sshd_socket_accept: false

--- a/vars/Debian_13.yml
+++ b/vars/Debian_13.yml
@@ -18,6 +18,6 @@ __sshd_runtime_directory: sshd
 __sshd_environment_file: /etc/default/ssh
 __sshd_environment_variable:
   - SSHD_OPTS
-__sshd_service_after: auditd.service
+__sshd_service_after: nss-user-lookup.target auditd.service
 __sshd_service_alias: sshd
 __sshd_socket_accept: false


### PR DESCRIPTION
Enhancement: Add support for Debian 13 (aka Trixie)

Reason: 
Like two years ago (#283) the next debian release is near.
Debian 13 Release is planned for 2025-08-09 (https://wiki.debian.org/DebianTrixie)

Result: Support for Debian 13

Issue Tracker Tickets (Jira or BZ if any): -
