### PR TITLE
fix: include external config files first so they can override all options

### DIFF
--- a/meta/options_body
+++ b/meta/options_body
@@ -1,3 +1,4 @@
+Include
 Port
 AddressFamily
 ListenAddress
@@ -50,7 +51,6 @@ HostbasedAcceptedKeyTypes
 HostbasedAcceptedAlgorithms
 HostbasedAuthentication
 HostbasedUsesNameFromPacketOnly
-Include
 IPQoS
 IgnoreRhosts
 IgnoreUserKnownHosts

--- a/meta/options_match
+++ b/meta/options_match
@@ -1,3 +1,4 @@
+Include
 AcceptEnv
 AllowAgentForwarding
 AllowGroups
@@ -29,7 +30,6 @@ HostbasedAcceptedAlgorithms
 HostbasedAuthentication
 HostbasedUsesNameFromPacketOnly
 IgnoreRhosts
-Include
 IPQoS
 KbdInteractiveAuthentication
 KerberosAuthentication

--- a/templates/sshd_config.j2
+++ b/templates/sshd_config.j2
@@ -51,6 +51,7 @@
 {%   if match_list is iterable %}
 {%     for match in match_list %}
 Match {{ match["Condition"] }}
+{{       render_option("Include",match["Include"],true) -}}
 {{       render_option("AcceptEnv",match["AcceptEnv"],true) -}}
 {{       render_option("AllowAgentForwarding",match["AllowAgentForwarding"],true) -}}
 {{       render_option("AllowGroups",match["AllowGroups"],true) -}}
@@ -82,7 +83,6 @@ Match {{ match["Condition"] }}
 {{       render_option("HostbasedAuthentication",match["HostbasedAuthentication"],true) -}}
 {{       render_option("HostbasedUsesNameFromPacketOnly",match["HostbasedUsesNameFromPacketOnly"],true) -}}
 {{       render_option("IgnoreRhosts",match["IgnoreRhosts"],true) -}}
-{{       render_option("Include",match["Include"],true) -}}
 {{       render_option("IPQoS",match["IPQoS"],true) -}}
 {{       render_option("KbdInteractiveAuthentication",match["KbdInteractiveAuthentication"],true) -}}
 {{       render_option("KerberosAuthentication",match["KerberosAuthentication"],true) -}}
@@ -131,6 +131,7 @@ Match {{ match["Condition"] }}
 {{     match_block(match_list) -}}
 {%   endif %}
 {% endmacro %}
+{{ body_option("Include",sshd_Include) -}}
 {{ body_option("Port",sshd_Port) -}}
 {{ body_option("AddressFamily",sshd_AddressFamily) -}}
 {{ body_option("ListenAddress",sshd_ListenAddress) -}}
@@ -183,7 +184,6 @@ Match {{ match["Condition"] }}
 {{ body_option("HostbasedAcceptedAlgorithms",sshd_HostbasedAcceptedAlgorithms) -}}
 {{ body_option("HostbasedAuthentication",sshd_HostbasedAuthentication) -}}
 {{ body_option("HostbasedUsesNameFromPacketOnly",sshd_HostbasedUsesNameFromPacketOnly) -}}
-{{ body_option("Include",sshd_Include) -}}
 {{ body_option("IPQoS",sshd_IPQoS) -}}
 {{ body_option("IgnoreRhosts",sshd_IgnoreRhosts) -}}
 {{ body_option("IgnoreUserKnownHosts",sshd_IgnoreUserKnownHosts) -}}

--- a/templates/sshd_config_snippet.j2
+++ b/templates/sshd_config_snippet.j2
@@ -49,6 +49,7 @@
 {%   if match_list is iterable %}
 {%     for match in match_list %}
 Match {{ match["Condition"] }}
+{{       render_option("Include",match["Include"],true) -}}
 {{       render_option("AcceptEnv",match["AcceptEnv"],true) -}}
 {{       render_option("AllowAgentForwarding",match["AllowAgentForwarding"],true) -}}
 {{       render_option("AllowGroups",match["AllowGroups"],true) -}}
@@ -80,7 +81,6 @@ Match {{ match["Condition"] }}
 {{       render_option("HostbasedAuthentication",match["HostbasedAuthentication"],true) -}}
 {{       render_option("HostbasedUsesNameFromPacketOnly",match["HostbasedUsesNameFromPacketOnly"],true) -}}
 {{       render_option("IgnoreRhosts",match["IgnoreRhosts"],true) -}}
-{{       render_option("Include",match["Include"],true) -}}
 {{       render_option("IPQoS",match["IPQoS"],true) -}}
 {{       render_option("KbdInteractiveAuthentication",match["KbdInteractiveAuthentication"],true) -}}
 {{       render_option("KerberosAuthentication",match["KerberosAuthentication"],true) -}}
@@ -129,6 +129,7 @@ Match {{ match["Condition"] }}
 {{     match_block(match_list) -}}
 {%   endif %}
 {% endmacro %}
+{{ body_option("Include",sshd_Include) -}}
 {{ body_option("Port",sshd_Port) -}}
 {{ body_option("AddressFamily",sshd_AddressFamily) -}}
 {{ body_option("ListenAddress",sshd_ListenAddress) -}}
@@ -181,7 +182,6 @@ Match {{ match["Condition"] }}
 {{ body_option("HostbasedAcceptedAlgorithms",sshd_HostbasedAcceptedAlgorithms) -}}
 {{ body_option("HostbasedAuthentication",sshd_HostbasedAuthentication) -}}
 {{ body_option("HostbasedUsesNameFromPacketOnly",sshd_HostbasedUsesNameFromPacketOnly) -}}
-{{ body_option("Include",sshd_Include) -}}
 {{ body_option("IPQoS",sshd_IPQoS) -}}
 {{ body_option("IgnoreRhosts",sshd_IgnoreRhosts) -}}
 {{ body_option("IgnoreUserKnownHosts",sshd_IgnoreUserKnownHosts) -}}


### PR DESCRIPTION
Enhancement: Put the `Include` config option always at the top

Reason: see #314

Result: always load included configs first

Issue Tracker Tickets (Jira or BZ if any):
