### PR TITLE
feat: Support for daemon reload, socket restart and systemd socket file to match Ubuntu 24.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,18 +96,29 @@ for AIX)
 
 #### sshd_allow_reload
 
-If set to *false*, a reload of sshd won't happen on change. This can help with
-troubleshooting. You'll need to manually reload sshd if you want to apply the
-changed configuration. Defaults to *true*.
+If set to *false*, a reload of sshd service won't happen on change. This can
+help with troubleshooting. You'll need to manually reload sshd if you want to
+apply the changed configuration. Defaults to *true*.
 
 #### sshd_allow_restart
 
-Some changes, for example of the sysconfig and environment files require the full
-restart of the service. If set to *false*, a restart of sshd won't happen on these
-changes. This can help with troubleshooting. You'll need to manually restart sshd
-if you want to apply the changed configuration. Defaults to *true* (except on AIX
-where the reload is handled by specific restart command and this option does not
-have any effect).
+Some changes, for example of the sysconfig and environment files require
+the full restart of the service. If set to *false*, a restart of sshd service
+won't happen on these changes. This can help with troubleshooting.
+You'll need to manually restart sshd service if you want to apply the changed
+configuration. Defaults to *true* (except on AIX where the reload is
+handled by specific restart command and this option does not have any effect).
+
+#### sshd_socket_allow_restart
+
+The systemd can run sshd either as a service or a socket, handling part of
+the network communication (default depends on the OS). After making changes
+to the socket unit or to the configuration defining the ports and addresses
+the systemd listens to, the socket unit needs to be restarted.
+If set to *false*, a restart of sshd socket won't happen on these changes.
+This can help with troubleshooting.
+You'll need to manually restart sshd socket if you want to apply the changed
+configuration. Defaults to *true*.
 
 #### sshd_allow_daemon_reload
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,14 @@ unless: Running inside a docker container (it is assumed ansible is used during
 build phase) or AIX (Ansible `service` module does not currently support `enabled`
 for AIX)
 
+#### sshd_systemd_unit
+
+Selection among `service` and `socket`, which is used in systemd to handle
+the sshd connection. Only one can be active at a time, otherwise both
+sshd and systemd will try to bind the same port and one of them will fail.
+Default depends on OS. Most of them use `service`, but recent Ubuntu switched
+to using `socket` by default.
+
 #### sshd_allow_reload
 
 If set to *false*, a reload of sshd service won't happen on change. This can

--- a/README.md
+++ b/README.md
@@ -109,6 +109,19 @@ if you want to apply the changed configuration. Defaults to *true* (except on AI
 where the reload is handled by specific restart command and this option does not
 have any effect).
 
+#### sshd_allow_daemon_reload
+
+The `systemd` daemon needs to be reloaded in the following cases:
+
+* When the `systemd` is used to manage the service and/or socket
+* When the ports or listen addresses are changed to non-default values and they
+  are automatically picked up by the `sshd-socket-generator`
+  (such as in Ubuntu 24.04).
+
+If set to *false*, a the `systemd` daemon won't be reloaded on these changes.
+This can help with troubleshooting. You'll need to manually reload the `systemd`
+daemon if you want to apply the changed configuration. Defaults to *true*.
+
 #### sshd_install_service
 
 If set to *true*, the role will install service files for the ssh service.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,11 +13,14 @@ sshd_manage_service: true
 # If the below is false, don't reload the systemd daemon on change of the service or socket
 sshd_allow_daemon_reload: true
 
-# If the below is false, don't reload the ssh daemon on change
+# If the below is false, don't reload the ssh service on change
 sshd_allow_reload: true
 
-# If the below is false, don't restart the ssh daemon on change that requires restart
+# If the below is false, don't restart the ssh service on change that requires restart
 sshd_allow_restart: true
+
+# If the below is false, don't restart the ssh socket on change that requires restart
+sshd_socket_allow_restart: true
 
 # If the below is true, also install service files from the templates pointed
 # to by the `sshd_service_template_*` variables
@@ -104,3 +107,9 @@ sshd_manage_firewall: false
 # If this option is enabled, the role will configure selinux to allow sshd to
 # bind the ports defined in the configuration. This works only on Red Hat based systems.
 sshd_manage_selinux: false
+
+# Selection among `service` and `socket`, which is used in systemd to handle
+# the sshd connection. Only one can be active at a time, otherwise both
+# sshd and systemd will try to bind the same port and one of them will fail.
+# Default depends on OS.
+sshd_systemd_unit: "{{ __sshd_systemd_unit }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,6 +10,9 @@ sshd_skip_defaults: false
 # daemon at all
 sshd_manage_service: true
 
+# If the below is false, don't reload the systemd daemon on change of the service or socket
+sshd_allow_daemon_reload: true
+
 # If the below is false, don't reload the ssh daemon on change
 sshd_allow_reload: true
 

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,11 +1,23 @@
 ---
 
+- name: Systemd daemon is reloaded when needed
+  ansible.builtin.command: systemctl daemon-reload  # noqa command-instead-of-module
+  # # Can not use systemd_service as it fails on the old Ansible even if not executed
+  # ansible.builtin.systemd_service:
+  #   daemon_reload: true
+  when:
+    - sshd_manage_service | bool
+    - ansible_facts['virtualization_type'] | default(None) not in __sshd_skip_virt_env
+    - ansible_connection != 'chroot'
+  listen: sshd_daemon_reload
+  changed_when: true
+
 - name: Reload the SSH service
   ansible.builtin.service:
     name: "{{ sshd_service }}"
     state: reloaded
   when:
-    - sshd_allow_reload|bool
+    - sshd_allow_reload | bool
     - ansible_facts['virtualization_type'] | default(None) not in __sshd_skip_virt_env
     - ansible_connection != 'chroot'
     - ansible_facts['os_family'] != 'AIX'
@@ -17,7 +29,7 @@
     name: "{{ sshd_service }}"
     state: restarted
   when:
-    - sshd_allow_restart|bool
+    - sshd_allow_restart | bool
     - ansible_facts['virtualization_type'] | default(None) not in __sshd_skip_virt_env
     - ansible_connection != 'chroot'
     - ansible_facts['os_family'] != 'AIX'
@@ -40,7 +52,7 @@
   listen: sshd_reload
   changed_when: false
   when:
-    - sshd_allow_reload|bool
+    - sshd_allow_reload | bool
     - ansible_facts['os_family'] == 'AIX'
 
 # sshd on OpenWrt does not support reloading a service, it has to be restarted instead
@@ -49,6 +61,6 @@
     name: "{{ sshd_service }}"
     state: restarted
   when:
-    - sshd_allow_reload|bool
+    - sshd_allow_reload | bool
     - ansible_facts['os_family'] == 'OpenWrt'
   listen: sshd_reload

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -6,7 +6,6 @@
   # ansible.builtin.systemd_service:
   #   daemon_reload: true
   when:
-    - sshd_manage_service | bool
     - ansible_facts['virtualization_type'] | default(None) not in __sshd_skip_virt_env
     - ansible_connection != 'chroot'
   listen: sshd_daemon_reload

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -36,6 +36,16 @@
     - ansible_facts['os_family'] != 'OpenWrt'
   listen: sshd_restart
 
+- name: Restart the SSH socket
+  ansible.builtin.service:
+    name: "{{ sshd_service }}.socket"
+    state: restarted
+  when:
+    - sshd_allow_restart | bool
+    - ansible_facts['virtualization_type'] | default(None) not in __sshd_skip_virt_env
+    - ansible_connection != 'chroot'
+  listen: sshd_socket_restart
+
 # sshd on AIX cannot be 'reloaded', it must be Stopped+Started.
 # It's dangerous to do this in two tasks.. you're stopping SSH and then trying to SSH back in to start it.
 # Instead, use a dirty shell script:

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -18,6 +18,7 @@
     state: reloaded
   when:
     - sshd_allow_reload | bool
+    - sshd_systemd_unit == 'service'
     - ansible_facts['virtualization_type'] | default(None) not in __sshd_skip_virt_env
     - ansible_connection != 'chroot'
     - ansible_facts['os_family'] != 'AIX'
@@ -30,6 +31,7 @@
     state: restarted
   when:
     - sshd_allow_restart | bool
+    - sshd_systemd_unit == 'service'
     - ansible_facts['virtualization_type'] | default(None) not in __sshd_skip_virt_env
     - ansible_connection != 'chroot'
     - ansible_facts['os_family'] != 'AIX'
@@ -42,6 +44,7 @@
     state: restarted
   when:
     - sshd_allow_restart | bool
+    - sshd_systemd_unit == 'socket'
     - ansible_facts['virtualization_type'] | default(None) not in __sshd_skip_virt_env
     - ansible_connection != 'chroot'
   listen: sshd_socket_restart

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -6,6 +6,7 @@
   # ansible.builtin.systemd_service:
   #   daemon_reload: true
   when:
+    - sshd_allow_daemon_reload | bool
     - ansible_facts['virtualization_type'] | default(None) not in __sshd_skip_virt_env
     - ansible_connection != 'chroot'
   listen: sshd_daemon_reload

--- a/tasks/find_bind_addresses.yml
+++ b/tasks/find_bind_addresses.yml
@@ -1,0 +1,24 @@
+---
+- name: Find the bind addresses the ssh service is going to use
+  vars:
+    # This mimics the macro body_option() in sshd_config.j2
+    # The explicit to_json filter is needed for Python 2 compatibility
+    __sshd_listen_from_config_tmp: >-
+      {%- if sshd_ListenAddress is defined -%}
+      {{-   sshd_ListenAddress | to_json -}}
+      {%- elif __sshd_config['ListenAddress'] is defined -%}
+      {{-   __sshd_config['ListenAddress'] | to_json -}}
+      {%- elif __sshd_defaults['ListenAddress'] is defined and not sshd_skip_defaults -%}
+      {{-   __sshd_defaults['ListenAddress'] | to_json -}}
+      {%- else -%}
+      {{-   ["0.0.0.0", "[::]"] | to_json -}}
+      {%- endif -%}
+  ansible.builtin.set_fact:
+    __sshd_listen_addresses_from_config: >-
+      {%- if __sshd_listen_from_config_tmp | type_debug == "list" -%}
+      {{-    __sshd_listen_from_config_tmp | to_json -}}
+      {%- elif __sshd_listen_from_config_tmp | from_json is string or __sshd_listen_from_config_tmp | from_json is number -%}
+      {{-   [__sshd_listen_from_config_tmp | from_json] | to_json -}}
+      {%- else -%}
+      {{-   __sshd_listen_from_config_tmp -}}
+      {%- endif -%}

--- a/tasks/find_ports.yml
+++ b/tasks/find_ports.yml
@@ -22,7 +22,3 @@
       {%- else -%}
       {{-   __sshd_ports_from_config_tmp -}}
       {%- endif -%}
-  when:
-    - sshd_manage_firewall | bool or sshd_manage_selinux | bool
-    - ansible_facts['os_family'] == 'RedHat'
-    - ansible_facts['virtualization_type'] | default(None) not in __sshd_skip_virt_env

--- a/tasks/find_ports.yml
+++ b/tasks/find_ports.yml
@@ -4,22 +4,24 @@
     # This mimics the macro body_option() in sshd_config.j2
     # The explicit to_json filter is needed for Python 2 compatibility
     __sshd_ports_from_config_tmp: >-
-      {% if sshd_Port is defined %}
-        {{ sshd_Port | to_json }}
-      {% elif __sshd_config['Port'] is defined %}
-        {{ __sshd_config['Port'] | to_json }}
-      {% elif __sshd_defaults['Port'] is defined and not sshd_skip_defaults %}
-        {{ __sshd_defaults['Port'] | to_json }}
-      {% else %}
-        {{ [22] | to_json }}
-      {% endif %}
+      {%- if sshd_Port is defined -%}
+      {{-   sshd_Port | to_json -}}
+      {%- elif __sshd_config['Port'] is defined -%}
+      {{-   __sshd_config['Port'] | to_json -}}
+      {%- elif __sshd_defaults['Port'] is defined and not sshd_skip_defaults -%}
+      {{-   __sshd_defaults['Port'] | to_json -}}
+      {%- else -%}
+      {{-   [22] | to_json -}}
+      {%- endif -%}
   ansible.builtin.set_fact:
     __sshd_ports_from_config: >-
-      {% if __sshd_ports_from_config_tmp | from_json is string or __sshd_ports_from_config_tmp | from_json is number %}
-        {{ [__sshd_ports_from_config_tmp | from_json] | to_json }}
-      {% else %}
-        {{ __sshd_ports_from_config_tmp }}
-      {% endif %}
+      {%- if __sshd_ports_from_config_tmp | type_debug == "list" -%}
+      {{-   __sshd_ports_from_config_tmp | to_json -}}
+      {%- elif __sshd_ports_from_config_tmp | from_json is string or __sshd_ports_from_config_tmp | from_json is number -%}
+      {{-   [__sshd_ports_from_config_tmp | from_json] | to_json -}}
+      {%- else -%}
+      {{-   __sshd_ports_from_config_tmp -}}
+      {%- endif -%}
   when:
     - sshd_manage_firewall | bool or sshd_manage_selinux | bool
     - ansible_facts['os_family'] == 'RedHat'

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -129,6 +129,9 @@
     - name: Find SSHD ports
       ansible.builtin.include_tasks: find_ports.yml
 
+    - name: Find SSHD bind addresses
+      ansible.builtin.include_tasks: find_bind_addresses.yml
+
     - name: Configure firewall
       ansible.builtin.include_tasks: firewall.yml
       when:

--- a/tasks/install_config.yml
+++ b/tasks/install_config.yml
@@ -37,6 +37,7 @@
   notify:
     - sshd_daemon_reload
     - sshd_restart
+    - sshd_socket_restart
 
 - name: Make sure the include path is present in the main sshd_config
   ansible.builtin.lineinfile:

--- a/tasks/install_config.yml
+++ b/tasks/install_config.yml
@@ -25,6 +25,18 @@
       {% endif %}
     backup: "{{ sshd_backup }}"
   notify: sshd_reload
+  register: __sshd_config_result
+
+- name: Notify systemd to reload daemon and restart the service
+  ansible.builtin.assert: { that: true, quiet: true }
+  changed_when: true
+  when:
+    - __sshd_config_result is changed
+    - not __sshd_socket_accept
+    - __sshd_listen_addresses_from_config != '["0.0.0.0", "[::]"]' or __sshd_ports_from_config != "[22]"
+  notify:
+    - sshd_daemon_reload
+    - sshd_restart
 
 - name: Make sure the include path is present in the main sshd_config
   ansible.builtin.lineinfile:

--- a/tasks/install_service.yml
+++ b/tasks/install_service.yml
@@ -24,8 +24,9 @@
         group: root
         mode: "0644"
       notify:
-        - sshd_reload
         - sshd_daemon_reload
+        - sshd_reload
+        - sshd_socket_restart
       when:
         - __sshd_socket_accept | bool
 
@@ -37,8 +38,9 @@
         group: root
         mode: "0644"
       notify:
-        - sshd_reload
         - sshd_daemon_reload
+        - sshd_reload
+        - sshd_socket_restart
 
 - name: Service enabled and running
   ansible.builtin.service:

--- a/tasks/install_service.yml
+++ b/tasks/install_service.yml
@@ -12,7 +12,9 @@
         owner: root
         group: root
         mode: "0644"
-      notify: sshd_reload
+      notify:
+        - sshd_reload
+        - sshd_daemon_reload
 
     - name: Install instanced service unit file
       ansible.builtin.template:
@@ -21,7 +23,9 @@
         owner: root
         group: root
         mode: "0644"
-      notify: sshd_reload
+      notify:
+        - sshd_reload
+        - sshd_daemon_reload
       when:
         - __sshd_socket_accept | bool
 
@@ -32,7 +36,9 @@
         owner: root
         group: root
         mode: "0644"
-      notify: sshd_reload
+      notify:
+        - sshd_reload
+        - sshd_daemon_reload
 
 - name: Service enabled and running
   ansible.builtin.service:

--- a/templates/sshd.socket.j2
+++ b/templates/sshd.socket.j2
@@ -8,9 +8,20 @@ Before=sockets.target
 {% endif %}
 
 [Socket]
-{% for port in __sshd_ports_from_config %}
+{% set ports = __sshd_ports_from_config if __sshd_ports_from_config | type_debug == "list" else __sshd_ports_from_config | from_json %}
+{% set addrs = __sshd_listen_addresses_from_config if __sshd_listen_addresses_from_config | type_debug == "list" else __sshd_listen_addresses_from_config | from_json %}
+{% for port in ports %}
+{%  if addrs != ["0.0.0.0", "[::]"] or __sshd_socket_expanded_listen %}
+{%   for addr in addrs %}
+ListenStream={{ addr }}:{{ port }}
+{%   endfor %}
+{%  else %}
 ListenStream={{ port }}
+{%  endif %}
 {% endfor %}
+{% if __sshd_socket_bind_ipv6only %}
+BindIPv6Only=ipv6-only
+{% endif %}
 {% if __sshd_socket_accept %}
 Accept=yes
 {% else %}

--- a/templates/sshd.socket.j2
+++ b/templates/sshd.socket.j2
@@ -8,7 +8,9 @@ Before=sockets.target
 {% endif %}
 
 [Socket]
-ListenStream=22
+{% for port in __sshd_ports_from_config %}
+ListenStream={{ port }}
+{% endfor %}
 {% if __sshd_socket_accept %}
 Accept=yes
 {% else %}

--- a/tests/tests_systemd_socket_listen.yml
+++ b/tests/tests_systemd_socket_listen.yml
@@ -1,0 +1,65 @@
+---
+- name: Test port is propagated to systemd socket service
+  hosts: all
+  vars:
+    __sshd_test_backup_files:
+      - /etc/ssh/sshd_config
+      - /etc/ssh/sshd_config.d/00-ansible_system_role.conf
+      - /etc/systemd/system/sshd.service
+      - /etc/systemd/system/sshd@.service
+      - /etc/systemd/system/sshd.socket
+      - /etc/systemd/system/ssh.service
+      - /etc/systemd/system/ssh@.service
+      - /etc/systemd/system/ssh.socket
+    __sshd_test_service_name: sshd
+    __sshd_service_list: []
+    __sshd_service_inst_list: []
+    __sshd_socket_list: []
+  tasks:
+    - name: Fix the service name on Debian
+      ansible.builtin.set_fact:
+        __sshd_test_service_name: ssh
+      when:
+        - ansible_facts['os_family'] == "Debian"
+
+    - name: Backup configuration files
+      ansible.builtin.include_tasks: tasks/backup.yml
+
+    - name: Configure sshd with default options and install service files
+      ansible.builtin.include_role:
+        name: ansible-sshd
+      vars:
+        sshd_install_service: true
+        sshd_config:
+          ListenAddress:
+            - 1.2.3.4
+            - "[::42]"
+          Port:
+            - 33
+            - 3333
+
+    - name: Read the socket file and verify it contains correct ports
+      tags: tests::verify
+      when:
+        - ansible_facts['service_mgr'] == 'systemd' or
+          (ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution_major_version'] == '7')
+      block:
+        - name: Read the created socket file
+          ansible.builtin.slurp:
+            src: "/etc/systemd/system/{{ __sshd_test_service_name }}.socket"
+          register: socket
+
+        - name: Print the generated socket file
+          ansible.builtin.debug:
+            msg: "{{ socket.content | b64decode }}"
+
+        - name: Test port is propagated to sshd.socket
+          ansible.builtin.assert:
+            that:
+              - "'ListenStream=1.2.3.4:33' in socket.content | b64decode"
+              - "'ListenStream=[::42]:33' in socket.content | b64decode"
+              - "'ListenStream=1.2.3.4:3333' in socket.content | b64decode"
+              - "'ListenStream=[::42]:3333' in socket.content | b64decode"
+
+    - name: "Restore configuration files"
+      ansible.builtin.include_tasks: tasks/restore.yml

--- a/tests/tests_systemd_socket_port.yml
+++ b/tests/tests_systemd_socket_port.yml
@@ -1,0 +1,64 @@
+---
+- name: Test port is propagated to systemd socket service
+  hosts: all
+  vars:
+    __sshd_test_backup_files:
+      - /etc/ssh/sshd_config
+      - /etc/ssh/sshd_config.d/00-ansible_system_role.conf
+      - /etc/systemd/system/sshd.service
+      - /etc/systemd/system/sshd@.service
+      - /etc/systemd/system/sshd.socket
+      - /etc/systemd/system/ssh.service
+      - /etc/systemd/system/ssh@.service
+      - /etc/systemd/system/ssh.socket
+    __sshd_test_service_name: sshd
+    __sshd_service_list: []
+    __sshd_service_inst_list: []
+    __sshd_socket_list: []
+  tasks:
+    - name: Fix the service name on Debian
+      ansible.builtin.set_fact:
+        __sshd_test_service_name: ssh
+      when:
+        - ansible_facts['os_family'] == "Debian"
+
+    - name: Backup configuration files
+      ansible.builtin.include_tasks: tasks/backup.yml
+
+    - name: Configure sshd with default options and install service files
+      ansible.builtin.include_role:
+        name: ansible-sshd
+      vars:
+        sshd_install_service: true
+        sshd_config:
+          Port:
+            - 33
+            - 3333
+
+    - name: Read the socket file and verify it contains correct ports
+      tags: tests::verify
+      when:
+        - ansible_facts['service_mgr'] == 'systemd' or
+          (ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution_major_version'] == '7')
+      block:
+        - name: Read the created socket file
+          ansible.builtin.slurp:
+            src: "/etc/systemd/system/{{ __sshd_test_service_name }}.socket"
+          register: socket
+
+        - name: Print the generated socket file
+          ansible.builtin.debug:
+            msg: "{{ socket.content | b64decode }}"
+
+        - name: Test port is propagated to sshd.socket
+          ansible.builtin.assert:
+            that:
+              - "'ListenStream=33' in socket.content | b64decode or
+                ('ListenStream=0.0.0.0:33' in socket.content | b64decode and
+                 'ListenStream=[::]:33' in socket.content | b64decode)"
+              - "'ListenStream=3333' in socket.content | b64decode or
+                ('ListenStream=0.0.0.0:3333' in socket.content | b64decode and
+                 'ListenStream=[::]:3333' in socket.content | b64decode)"
+
+    - name: "Restore configuration files"
+      ansible.builtin.include_tasks: tasks/restore.yml

--- a/vars/Ubuntu_24.yml
+++ b/vars/Ubuntu_24.yml
@@ -32,3 +32,5 @@ __sshd_service_alias: sshd
 __sshd_socket_accept: false
 __sshd_socket_freebind: true
 __sshd_socket_required_by: ssh.service
+__sshd_socket_expanded_listen: true
+__sshd_socket_bind_ipv6only: true

--- a/vars/Ubuntu_24.yml
+++ b/vars/Ubuntu_24.yml
@@ -34,3 +34,4 @@ __sshd_socket_freebind: true
 __sshd_socket_required_by: ssh.service
 __sshd_socket_expanded_listen: true
 __sshd_socket_bind_ipv6only: true
+__sshd_systemd_unit: "socket"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -101,3 +101,6 @@ __sshd_socket_expanded_listen: false
 
 # Bind SSHD socket only to IPv6
 __sshd_socket_bind_ipv6only: false
+
+# Most of the distribution use sshd daemon directly as a service
+__sshd_systemd_unit: "service"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -95,3 +95,9 @@ __sshd_socket_freebind: ~
 
 # Space separated list of service names that this socket is required by
 __sshd_socket_required_by: ~
+
+# Expand the list of bind addresses even if the default is used
+__sshd_socket_expanded_listen: false
+
+# Bind SSHD socket only to IPv6
+__sshd_socket_bind_ipv6only: false


### PR DESCRIPTION
Enhancement: Adjust generated systemd socket file to contain actual ports and addresses from the configuration file, add support for the systemctl daemon reload and sshd socket restart.

Reason: The new Ubuntu landed with changed socket file. We also need to reload systemd daemon when we change these, which was reported in #307. 

Result: The generated socket file matches configured port and addresses and systemd daemon is properly reloaded and sshd socket restarted on relevant changes.

Issue Tracker Tickets (Jira or BZ if any): - 