### PR TITLE
fix: New configuration option in CentOS 10

### DIFF
--- a/.github/workflows/ansible-debian-check.yml
+++ b/.github/workflows/ansible-debian-check.yml
@@ -30,17 +30,3 @@ jobs:
           hosts: localhost
           targets: "tests/tests_*.yml"
           requirements: tests/requirements.yml
-
-  debian-buster:
-    runs-on: ubuntu-latest
-    steps:
-      - name: checkout PR
-        uses: actions/checkout@v4
-
-      - name: ansible check with debian buster (10)
-        uses: roles-ansible/check-ansible-debian-buster-action@master
-        with:
-          group: local
-          hosts: localhost
-          targets: "tests/tests_*.yml"
-          requirements: tests/requirements.yml

--- a/meta/options_body
+++ b/meta/options_body
@@ -37,6 +37,7 @@ GatewayPorts
 GSSAPIAuthentication
 GSSAPICleanupCredentials
 GSSAPIEnablek5users
+GSSAPIIndicators
 GSSAPIKeyExchange
 GSSAPIKexAlgorithms
 GSSAPIStoreCredentialsOnRekey

--- a/templates/sshd_config.j2
+++ b/templates/sshd_config.j2
@@ -170,6 +170,7 @@ Match {{ match["Condition"] }}
 {{ body_option("GSSAPIAuthentication",sshd_GSSAPIAuthentication) -}}
 {{ body_option("GSSAPICleanupCredentials",sshd_GSSAPICleanupCredentials) -}}
 {{ body_option("GSSAPIEnablek5users",sshd_GSSAPIEnablek5users) -}}
+{{ body_option("GSSAPIIndicators",sshd_GSSAPIIndicators) -}}
 {{ body_option("GSSAPIKeyExchange",sshd_GSSAPIKeyExchange) -}}
 {{ body_option("GSSAPIKexAlgorithms",sshd_GSSAPIKexAlgorithms) -}}
 {{ body_option("GSSAPIStoreCredentialsOnRekey",sshd_GSSAPIStoreCredentialsOnRekey) -}}

--- a/templates/sshd_config_snippet.j2
+++ b/templates/sshd_config_snippet.j2
@@ -168,6 +168,7 @@ Match {{ match["Condition"] }}
 {{ body_option("GSSAPIAuthentication",sshd_GSSAPIAuthentication) -}}
 {{ body_option("GSSAPICleanupCredentials",sshd_GSSAPICleanupCredentials) -}}
 {{ body_option("GSSAPIEnablek5users",sshd_GSSAPIEnablek5users) -}}
+{{ body_option("GSSAPIIndicators",sshd_GSSAPIIndicators) -}}
 {{ body_option("GSSAPIKeyExchange",sshd_GSSAPIKeyExchange) -}}
 {{ body_option("GSSAPIKexAlgorithms",sshd_GSSAPIKexAlgorithms) -}}
 {{ body_option("GSSAPIStoreCredentialsOnRekey",sshd_GSSAPIStoreCredentialsOnRekey) -}}

--- a/tests/tests_systemd_services.yml
+++ b/tests/tests_systemd_services.yml
@@ -74,6 +74,10 @@
           loop:
             "{{ service_old.splitlines() }}"
 
+        - name: Print the generated service file
+          ansible.builtin.debug:
+            msg: "{{ service.content | b64decode }}"
+
         - name: Test options in sshd.service are kept
           ansible.builtin.assert:
             that:
@@ -104,6 +108,10 @@
             - not item.startswith("Description=")
           loop:
             "{{ socket_old.splitlines() }}"
+
+        - name: Print the generated socket file
+          ansible.builtin.debug:
+            msg: "{{ socket.content | b64decode }}"
 
         - name: Test options in sshd.socket are kept
           ansible.builtin.assert:
@@ -144,6 +152,10 @@
             - not item.startswith("Description=")
           loop:
             "{{ service_inst_old.splitlines() }}"
+
+        - name: Print the instantiated generated socket file
+          ansible.builtin.debug:
+            msg: "{{ service_inst.content | b64decode }}"
 
         - name: Test options in sshd@.service are kept
           ansible.builtin.assert:


### PR DESCRIPTION
Enhancement: Add a new configuration option `GSSAPIIndicators`.

Reason: The CentOS 10 comes with a new configuration option `GSSAPIIndicators`.

Result: The new configuration option can be used when configuring CentOS 10 machines.

Issue Tracker Tickets (Jira or BZ if any): -
