### PR TITLE
fix: Allow specifying OS vars from playbook_dir

### DIFF
--- a/tasks/variables.yml
+++ b/tasks/variables.yml
@@ -18,7 +18,7 @@
         __sshd_is_ostree: "{{ __ostree_booted_stat.stat.exists }}"
 
 - name: Set OS dependent variables
-  ansible.builtin.include_vars: "{{ lookup('first_found', params) }}"
+  ansible.builtin.include_vars: "{{ item }}"
   vars:
     _distribution_lts_offset: >-
       {{
@@ -33,13 +33,13 @@
         if ansible_facts['distribution'] == "Ubuntu"
         else ansible_facts['distribution_version']
       }}
-    params:
-      files:
+  with_first_found:
+    - files:
         - "{{ ansible_facts['distribution'] }}_{{ _distribution_lts_version }}.yml"
         - "{{ ansible_facts['os_family'] }}_{{ ansible_facts['distribution_major_version'] }}.yml"
         - "{{ ansible_facts['distribution'] }}.yml"
         - "{{ ansible_facts['os_family'] }}.yml"
-        - main.yml  # fallback, vars/main.yml is always loaded by Ansible
       paths:
         - "{{ role_path }}/vars"
         - "{{ playbook_dir }}/vars"
+      skip: true


### PR DESCRIPTION
Enhancement: Previously, the "first_found" lookup would always find the `role_path/vars/main.yml` file before any `playbook_dir/vars/...` file, so it was impossible to set variables from the second directory.

This change:
+ Removes `main.yml` from the lookup file names so that the automatically loaded `role_path/vars/main.yml` file can never stop another file from being loaded
+ Replaces the inline `lookup('first_found')` call with a `with_found_first` block so that the task won't fail if there is no additional vars file.

Result: The behaviour of the role should be identical, except that it is now possible to use the `{{ playbook_dir }}/vars/...` files that the role clearly intends to support.