### PR TITLE
feat: Add new configuration option CanonicalMatchUser on RHEL/CentOS

### DIFF
--- a/meta/options_body
+++ b/meta/options_body
@@ -18,6 +18,7 @@ AuthorizedPrincipalsCommand
 AuthorizedPrincipalsCommandUser
 AuthorizedPrincipalsFile
 Banner
+CanonicalMatchUser
 CASignatureAlgorithms
 ChallengeResponseAuthentication
 ChannelTimeout

--- a/templates/sshd_config.j2
+++ b/templates/sshd_config.j2
@@ -151,6 +151,7 @@ Match {{ match["Condition"] }}
 {{ body_option("AuthorizedPrincipalsCommandUser",sshd_AuthorizedPrincipalsCommandUser) -}}
 {{ body_option("AuthorizedPrincipalsFile",sshd_AuthorizedPrincipalsFile) -}}
 {{ body_option("Banner",sshd_Banner) -}}
+{{ body_option("CanonicalMatchUser",sshd_CanonicalMatchUser) -}}
 {{ body_option("CASignatureAlgorithms",sshd_CASignatureAlgorithms) -}}
 {{ body_option("ChallengeResponseAuthentication",sshd_ChallengeResponseAuthentication) -}}
 {{ body_option("ChannelTimeout",sshd_ChannelTimeout) -}}

--- a/templates/sshd_config_snippet.j2
+++ b/templates/sshd_config_snippet.j2
@@ -149,6 +149,7 @@ Match {{ match["Condition"] }}
 {{ body_option("AuthorizedPrincipalsCommandUser",sshd_AuthorizedPrincipalsCommandUser) -}}
 {{ body_option("AuthorizedPrincipalsFile",sshd_AuthorizedPrincipalsFile) -}}
 {{ body_option("Banner",sshd_Banner) -}}
+{{ body_option("CanonicalMatchUser",sshd_CanonicalMatchUser) -}}
 {{ body_option("CASignatureAlgorithms",sshd_CASignatureAlgorithms) -}}
 {{ body_option("ChallengeResponseAuthentication",sshd_ChallengeResponseAuthentication) -}}
 {{ body_option("ChannelTimeout",sshd_ChannelTimeout) -}}


### PR DESCRIPTION
Enhancement: Add a new configuration option CanonicalMatchUser.

Reason: CentOS 9 and 10 introduced the new configuration option `CanonicalMatchUser`.

Result: ansible-sshd can use the new configuration option CanonicalMatchUser

Issue Tracker Tickets (Jira or BZ if any): -