### PR TITLE
ci: remove ubuntu-focal tests as publicly EOL

### DIFF
--- a/.github/workflows/ansible-ubuntu.yml
+++ b/.github/workflows/ansible-ubuntu.yml
@@ -17,18 +17,3 @@ jobs:
           hosts: localhost
           targets: "tests/tests_*.yml"
           requirements: tests/requirements.yml
-
-  ubuntu-20:
-    runs-on: ubuntu-latest
-    steps:
-      # Important: This sets up your GITHUB_WORKSPACE environment variable
-      - name: checkout PR
-        uses: actions/checkout@v5
-
-      - name: ansible check with ubuntu:20 (focal)
-        uses: roles-ansible/check-ansible-ubuntu-focal-action@master
-        with:
-          group: local
-          hosts: localhost
-          targets: "tests/tests_*.yml"
-          requirements: tests/requirements.yml


### PR DESCRIPTION
Enhancement: Remove Ubuntu 20 GH workflow

Reason: Ubuntu 20 is publicly EOL
