### PR TITLE
Fix: Resolve 'length' filter error with boolean nofips variable

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -30,15 +30,15 @@
 - name: Check FIPS mode
   ansible.builtin.include_tasks: check_fips.yml
   when:
-    - __sshd_hostkeys_nofips | d([]) | length > 0
+    - (__sshd_hostkeys_nofips | d([], true) | list | length) > 0
 
 - name: Make sure hostkeys are available and have expected permissions
   vars:
     &share_vars # 'MAo=' evaluates to '0\n' in base 64 encoding, which is default
     __sshd_fips_mode: >-
-      {{ __sshd_hostkeys_nofips | d([]) | length > 0 and
-         (__sshd_kernel_fips_mode.content | d('MAo=') | b64decode | trim == '1' or
-          __sshd_userspace_fips_mode.content | d('MAo=') | b64decode | trim != '0') }}
+      {{ ((__sshd_hostkeys_nofips | d([], true) | list | length) > 0) and
+         ((__sshd_kernel_fips_mode.content | d('MAo=') | b64decode | trim) == '1' or
+          (__sshd_userspace_fips_mode.content | d('MAo=') | b64decode | trim) != '0') }}
     # This mimics the macro body_option() in sshd_config.j2
     # The explicit to_json filter is needed for Python 2 compatibility
     __sshd_hostkeys_from_config: >-


### PR DESCRIPTION
- Add explicit list conversion before applying length filter
- Use d([], true) to properly handle undefined/false values
- Fix FIPS mode condition evaluation in when clause
- Improves operator precedence with parentheses

Fixes error: 'ansible.builtin.length' failed: object of type 'bool' has no len()

Enhancement:

Reason:

Result:

Issue Tracker Tickets (Jira or BZ if any):
