### PR TITLE
feat: New OpenSSH configuration option GSSAPIDelegateCredentials

### DIFF
--- a/meta/options_body
+++ b/meta/options_body
@@ -38,6 +38,7 @@ ForceCommand
 GatewayPorts
 GSSAPIAuthentication
 GSSAPICleanupCredentials
+GSSAPIDelegateCredentials
 GSSAPIEnablek5users
 GSSAPIIndicators
 GSSAPIKeyExchange

--- a/templates/sshd_config.j2
+++ b/templates/sshd_config.j2
@@ -171,6 +171,7 @@ Match {{ match["Condition"] }}
 {{ body_option("GatewayPorts",sshd_GatewayPorts) -}}
 {{ body_option("GSSAPIAuthentication",sshd_GSSAPIAuthentication) -}}
 {{ body_option("GSSAPICleanupCredentials",sshd_GSSAPICleanupCredentials) -}}
+{{ body_option("GSSAPIDelegateCredentials",sshd_GSSAPIDelegateCredentials) -}}
 {{ body_option("GSSAPIEnablek5users",sshd_GSSAPIEnablek5users) -}}
 {{ body_option("GSSAPIIndicators",sshd_GSSAPIIndicators) -}}
 {{ body_option("GSSAPIKeyExchange",sshd_GSSAPIKeyExchange) -}}

--- a/templates/sshd_config_snippet.j2
+++ b/templates/sshd_config_snippet.j2
@@ -169,6 +169,7 @@ Match {{ match["Condition"] }}
 {{ body_option("GatewayPorts",sshd_GatewayPorts) -}}
 {{ body_option("GSSAPIAuthentication",sshd_GSSAPIAuthentication) -}}
 {{ body_option("GSSAPICleanupCredentials",sshd_GSSAPICleanupCredentials) -}}
+{{ body_option("GSSAPIDelegateCredentials",sshd_GSSAPIDelegateCredentials) -}}
 {{ body_option("GSSAPIEnablek5users",sshd_GSSAPIEnablek5users) -}}
 {{ body_option("GSSAPIIndicators",sshd_GSSAPIIndicators) -}}
 {{ body_option("GSSAPIKeyExchange",sshd_GSSAPIKeyExchange) -}}


### PR DESCRIPTION
Enhancement: Add a new option `GSSAPIDelegateCredentials`

Reason: The OpenSSH merged the new option recently (openssh/openssh-portable#614)

Result: The new option can be configured using ansible-sshd.

Issue Tracker Tickets (Jira or BZ if any): -