### PR TITLE
feat: Add systemd ephemeral authorized_keys to the instantiated service file on Fedora

### DIFF
--- a/templates/sshd@.service.j2
+++ b/templates/sshd@.service.j2
@@ -24,15 +24,26 @@ EnvironmentFile=-{{ file }}
 {%   endfor %}
 {% endif %}
 ExecStart=-{{ sshd_binary }} -i
-{%- for var in __sshd_environment_variable %} ${{ var }}{% endfor %} -f
-{%- if sshd_main_config_file is not none and sshd_config_file | dirname == sshd_main_config_file ~ '.d' %}
-{{- sshd_main_config_file }}
-{% else %}
-{{- sshd_config_file }}
-{% endif %}
+{%- for var in __sshd_environment_variable %} ${{ var }}{% endfor -%}
+{# When the system is not supporting drop-in directory and the config file is different than default #}
+{%- if sshd_main_config_file is none and sshd_config_file != __sshd_config_file %}
+ -f {{ sshd_config_file -}}
+{# When the system supports drop-in directory and its different from the distribution default and the file is in the directory that will be an include path #}
+{%- elif sshd_main_config_file is not none and sshd_main_config_file != __sshd_main_config_file and sshd_config_file | dirname == sshd_main_config_file ~ '.d' %}
+ -f {{ sshd_main_config_file -}}
+{# When the config file is different from distribution config just print it #}
+{%- elif sshd_config_file != __sshd_config_file %}
+ -f {{ sshd_config_file -}}
+{%- endif %}
+{%- if __sshd_service_ephemeral_authorized_keys %}
+ -o "AuthorizedKeysFile ${CREDENTIALS_DIRECTORY}/ssh.ephemeral-authorized_keys-all .ssh/authorized_keys"
+{%  endif %}
 StandardInput=socket
 {% if __sshd_runtime_directory is not none %}
 RuntimeDirectory={{ __sshd_runtime_directory }}
 RuntimeDirectoryPreserve=yes
 RuntimeDirectoryMode={{ __sshd_runtime_directory_mode }}
+{% endif %}
+{% if __sshd_service_ephemeral_authorized_keys %}
+ImportCredential=ssh.ephemeral-authorized_keys-all
 {% endif %}

--- a/tests/tests_second_service.yml
+++ b/tests/tests_second_service.yml
@@ -117,7 +117,8 @@
           ansible.builtin.assert:
             that:
               - "' -f/etc/ssh/sshd_config' not in service_inst.content | b64decode"
-              - "' -f/etc/ssh2/sshd_config' in service_inst.content | b64decode"
+              - "' -f /etc/ssh/sshd_config' not in service_inst.content | b64decode"
+              - "' -f /etc/ssh2/sshd_config' in service_inst.content | b64decode"
 
     - name: Stop second service
       ansible.builtin.service:

--- a/tests/tests_second_service_drop_in.yml
+++ b/tests/tests_second_service_drop_in.yml
@@ -129,7 +129,8 @@
               ansible.builtin.assert:
                 that:
                   - "' -f/etc/ssh/sshd_config' not in service_inst.content | b64decode"
-                  - "' -f/etc/ssh2/sshd_config' in service_inst.content | b64decode"
+                  - "' -f /etc/ssh/sshd_config' not in service_inst.content | b64decode"
+                  - "' -f /etc/ssh2/sshd_config' in service_inst.content | b64decode"
       always:
         - name: Stop second service
           ansible.builtin.service:

--- a/tests/tests_systemd_services.yml
+++ b/tests/tests_systemd_services.yml
@@ -164,10 +164,5 @@
           loop:
             "{{ __sshd_service_inst_list }}"
 
-        - name: Verify the ExecStart line contains the configuration file
-          ansible.builtin.assert:
-            that:
-              - "' -f/etc/ssh/' in service_inst.content | b64decode"
-
     - name: "Restore configuration files"
       ansible.builtin.include_tasks: tasks/restore.yml

--- a/vars/Fedora.yml
+++ b/vars/Fedora.yml
@@ -32,3 +32,4 @@ __sshd_service_wants:
   - sshd-keygen.target
   - ssh-host-keys-migration.service
 __sshd_service_restart_timeout: 42s
+__sshd_service_ephemeral_authorized_keys: "{{ ansible_facts['distribution_version'] is version('43', '>=') }}"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -87,6 +87,9 @@ __sshd_service_wants: ~
 # The systemd service RestartSec directive
 __sshd_service_restart_timeout: ~
 
+# Plug the systemd ephemeral authorized keys to the instantiated service file
+__sshd_service_ephemeral_authorized_keys: false
+
 # The systemd socket file does not accept the connection
 __sshd_socket_accept: true
 


### PR DESCRIPTION
Enhancement: Adjust instantiated systemd service file to match current Fedora version.

Reason: Fedora updated instantiated sshd service file

Result: We generate the matching instantiated systemd service file

Issue Tracker Tickets (Jira or BZ if any): Relevant: https://src.fedoraproject.org/rpms/openssh/pull-request/101