### PR TITLE
ci: ensure testing with INJECT_FACTS_AS_VARS=false

### DIFF
--- a/.github/workflows/ansible-alpine.yml
+++ b/.github/workflows/ansible-alpine.yml
@@ -2,6 +2,9 @@ name: Run Ansible Check on Alpine
 
 on: [push, pull_request]
 
+env:
+  ANSIBLE_INJECT_FACT_VARS: "false"
+
 jobs:
   alpine-latest:
     runs-on: ubuntu-latest

--- a/.github/workflows/ansible-centos-check.yml
+++ b/.github/workflows/ansible-centos-check.yml
@@ -2,6 +2,9 @@ name: Run Ansible Check on CentOS
 
 on: [push, pull_request]
 
+env:
+  ANSIBLE_INJECT_FACT_VARS: "false"
+
 jobs:
   centos-6:
     runs-on: ubuntu-latest

--- a/.github/workflows/ansible-debian-check.yml
+++ b/.github/workflows/ansible-debian-check.yml
@@ -2,6 +2,9 @@ name: Run tests on Debian
 
 on: [push, pull_request]
 
+env:
+  ANSIBLE_INJECT_FACT_VARS: "false"
+
 jobs:
   debian-trixie:
     runs-on: ubuntu-latest

--- a/.github/workflows/ansible-fedora.yml
+++ b/.github/workflows/ansible-fedora.yml
@@ -2,6 +2,9 @@ name: Run tests on Fedora latest
 
 on: [push, pull_request]
 
+env:
+  ANSIBLE_INJECT_FACT_VARS: "false"
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ansible-ubuntu.yml
+++ b/.github/workflows/ansible-ubuntu.yml
@@ -2,6 +2,9 @@ name: Run Ansible Check on Ubuntu
 
 on: [push, pull_request]
 
+env:
+  ANSIBLE_INJECT_FACT_VARS: "false"
+
 jobs:
   ubuntu-latest:
     runs-on: ubuntu-latest

--- a/README-ostree.md
+++ b/README-ostree.md
@@ -20,8 +20,8 @@ Usage:
 .ostree/get_ostree_data.sh packages runtime DISTRO-VERSION FORMAT
 ```
 
-`DISTRO-VERSION` is in the format that Ansible uses for `ansible_distribution`
-and `ansible_distribution_version` - for example, `Fedora-38`, `CentOS-8`,
+`DISTRO-VERSION` is in the format that Ansible uses for `ansible_facts["distribution"]`
+and `ansible_facts["distribution_version"]` - for example, `Fedora-38`, `CentOS-8`,
 `RedHat-9.4`
 
 `FORMAT` is one of `toml`, `json`, `yaml`, `raw`


### PR DESCRIPTION
An earlier commit fixed the code to work with INJECT_FACTS_AS_VARS=false

https://github.com/willshersystems/ansible-sshd/pull/244

This ensures testing with INJECT_FACTS_AS_VARS=false so that we can catch
any changes in the future which might break this.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
