### PR TITLE
test: ensure role gathers the facts it uses by having test clear_facts before include_role

### DIFF
--- a/.github/workflows/ansible-centos-check.yml
+++ b/.github/workflows/ansible-centos-check.yml
@@ -26,6 +26,9 @@ jobs:
         tests/tests_duplicate_role.yml
         tests/tests_os_defaults.yml
         tests/tests_firewall_selinux.yml
+    - run: >-
+        sed -i -e '/public: /d'
+        tests/tasks/run_role_with_clear_facts.yml
     - run: "sed -i -e 's/ansible.builtin.//g' -e 's/ansible.posix.//g' */*.yml */*/*.yml"
 
     - name: ansible check with centos 6

--- a/tasks/variables.yml
+++ b/tasks/variables.yml
@@ -1,9 +1,11 @@
 ---
 - name: Ensure ansible_facts used by role
   ansible.builtin.setup:
-    gather_subset: min
-  when: not ansible_facts.keys() | list |
-    intersect(__sshd_required_facts) == __sshd_required_facts
+    gather_subset:
+      - min
+      - virtual
+  when: __sshd_required_facts |
+    difference(ansible_facts.keys() | list) | length > 0
 
 - name: Determine if system is ostree and set flag
   when: not __sshd_is_ostree is defined

--- a/tests/tasks/run_role_with_clear_facts.yml
+++ b/tests/tasks/run_role_with_clear_facts.yml
@@ -3,8 +3,11 @@
 # Include this with include_tasks or import_tasks
 # Input:
 # - __sr_tasks_from: tasks_from to run - same as tasks_from in include_role
+#   https://docs.ansible.com/projects/ansible/latest/collections/ansible/builtin/include_role_module.html#parameter-tasks_from
 # - __sr_public: export private vars from role - same as public in include_role
-# - __sr_failed_when: set to false to ignore role errors - same as failed_when in include_role
+#   https://docs.ansible.com/projects/ansible/latest/collections/ansible/builtin/include_role_module.html#parameter-public
+# - __sr_failed_when: set to false to ignore role errors - same as failed_when keyword
+#   https://docs.ansible.com/projects/ansible/latest/playbook_guide/playbooks_error_handling.html#defining-failure
 - name: Clear facts
   ansible.builtin.meta: clear_facts
 

--- a/tests/tasks/run_role_with_clear_facts.yml
+++ b/tests/tasks/run_role_with_clear_facts.yml
@@ -1,0 +1,37 @@
+---
+# Task file: clear_facts, run ansible-sshd.
+# Include this with include_tasks or import_tasks
+# Input:
+# - __sr_tasks_from: tasks_from to run - same as tasks_from in include_role
+# - __sr_public: export private vars from role - same as public in include_role
+# - __sr_failed_when: set to false to ignore role errors - same as failed_when in include_role
+- name: Clear facts
+  ansible.builtin.meta: clear_facts
+
+# note that you can use failed_when with import_role but not with include_role
+# so this simulates the __sr_failed_when false case
+# Q: Why do we need a separate task to run the role normally?  Why not just
+# run the role in the block and rethrow the error in the rescue block?
+# A: Because you cannot rethrow the error in exactly the same way as the role does.
+# It might be possible to exactly reconstruct ansible_failed_result but it's not worth the effort.
+- name: Run the role with __sr_failed_when false
+  when:
+    - __sr_failed_when is defined
+    - not __sr_failed_when
+  block:
+    - name: Run the role
+      ansible.builtin.include_role:
+        name: ansible-sshd
+        tasks_from: "{{ __sr_tasks_from | default('main') }}"
+        public: "{{ __sr_public | default(false) }}"
+  rescue:
+    - name: Ignore the failure when __sr_failed_when is false
+      ansible.builtin.debug:
+        msg: Ignoring failure when __sr_failed_when is false
+
+- name: Run the role normally
+  ansible.builtin.include_role:
+    name: ansible-sshd
+    tasks_from: "{{ __sr_tasks_from | default('main') }}"
+    public: "{{ __sr_public | default(false) }}"
+  when: __sr_failed_when | d(true)

--- a/tests/tests_all_options.yml
+++ b/tests/tests_all_options.yml
@@ -1,7 +1,6 @@
 ---
 - name: Test we can handle all configuration options documented in manual page
   hosts: all
-  gather_facts: true
   vars:
     __sshd_test_backup_files:
       - /etc/dnf/dnf.conf
@@ -114,8 +113,7 @@
       when: not sshd_skip_test
 
     - name: Run role
-      ansible.builtin.include_role:
-        name: ansible-sshd
+      ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         # The configuration is not valid as we are using bogus values
         __sshd_supports_validate: false

--- a/tests/tests_alternative_file.yml
+++ b/tests/tests_alternative_file.yml
@@ -25,8 +25,7 @@
         shell: /sbin/nologin
 
     - name: Configure alternative sshd_config file
-      ansible.builtin.include_role:
-        name: ansible-sshd
+      ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         # just anything -- will not get processed by sshd
         sshd_config_file: /etc/ssh/sshd_config_custom
@@ -40,8 +39,7 @@
         sshd_LogLevel: DEBUG1  # noqa var-naming
 
     - name: Configure second alternative sshd_config file
-      ansible.builtin.include_role:
-        name: ansible-sshd
+      ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         # just anything -- will not get processed by sshd
         sshd_config_file: /etc/ssh/sshd_config_custom_second
@@ -52,8 +50,7 @@
         sshd_MaxStartups: 100  # noqa var-naming
 
     - name: Now configure the main sshd_config file
-      ansible.builtin.include_role:
-        name: ansible-sshd
+      ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         sshd_config_file: /etc/ssh/sshd_config
         sshd_config:

--- a/tests/tests_alternative_file_role.yml
+++ b/tests/tests_alternative_file_role.yml
@@ -27,8 +27,6 @@
 # Configure alternative sshd_config file
 - name: Test first alternative role file
   hosts: all
-  roles:
-    - ansible-sshd
   vars:
     # just anything -- will not get processed by sshd
     sshd_config_file: /etc/ssh/sshd_config_custom
@@ -40,12 +38,15 @@
       Banner: /etc/issue
       Ciphers: aes256-ctr
     sshd_LogLevel: DEBUG1  # noqa var-naming
+  tasks:
+    - name: Run ansible-sshd role
+      ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
+      vars:
+        __sr_public: true
 
 # Configure second alternative sshd_config file
 - name: Test first alternative role file
   hosts: all
-  roles:
-    - ansible-sshd
   vars:
     # just anything -- will not get processed by sshd
     sshd_config_file: /etc/ssh/sshd_config_custom_second
@@ -54,12 +55,15 @@
       Banner: /etc/issue2
       Ciphers: aes128-ctr
     sshd_MaxStartups: 100  # noqa var-naming
+  tasks:
+    - name: Run ansible-sshd role
+      ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
+      vars:
+        __sr_public: true
 
 # Now configure the main sshd_config file
 - name: Test main config file
   hosts: all
-  roles:
-    - ansible-sshd
   vars:
     sshd_config_file: /etc/ssh/sshd_config
     sshd_config:
@@ -68,6 +72,11 @@
       HostKey:
         - /tmp/ssh_host_ecdsa_key
     sshd_PasswordAuthentication: false  # noqa var-naming
+  tasks:
+    - name: Run ansible-sshd role
+      ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
+      vars:
+        __sr_public: true
 
 - name: Verify config files are correct
   hosts: all

--- a/tests/tests_backup.yml
+++ b/tests/tests_backup.yml
@@ -22,8 +22,7 @@
       with_items: "{{ backup_files.files }}"
 
     - name: Configure sshd without creating backup
-      ansible.builtin.include_role:
-        name: ansible-sshd
+      ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         sshd_backup: false
 
@@ -34,8 +33,7 @@
       register: no_backup
 
     - name: Configure sshd again with different configuration and with backup
-      ansible.builtin.include_role:
-        name: ansible-sshd
+      ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         sshd_Banner: /tmp/banner  # noqa var-naming
       register: second_run

--- a/tests/tests_certificates.yml
+++ b/tests/tests_certificates.yml
@@ -22,8 +22,7 @@
         shell: /sbin/nologin
 
     - name: Configure sshd
-      ansible.builtin.include_role:
-        name: ansible-sshd
+      ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         sshd_config:
           PasswordAuthentication: false

--- a/tests/tests_config_namespace.yml
+++ b/tests/tests_config_namespace.yml
@@ -11,8 +11,7 @@
       ansible.builtin.include_tasks: tasks/backup.yml
 
     - name: Add configuration block to default configuration file
-      ansible.builtin.include_role:
-        name: ansible-sshd
+      ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         sshd_config_file: /etc/ssh/sshd_config
         sshd_config_namespace: nm1
@@ -24,8 +23,7 @@
             AllowAgentForwarding: false
 
     - name: Add second configuration block to default configuration file
-      ansible.builtin.include_role:
-        name: ansible-sshd
+      ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         sshd_config_file: /etc/ssh/sshd_config
         sshd_config_namespace: nm2

--- a/tests/tests_default.yml
+++ b/tests/tests_default.yml
@@ -11,8 +11,11 @@
 
 - name: Test defaults
   hosts: all
-  roles:
-    - ansible-sshd
+  tasks:
+    - name: Run ansible-sshd role
+      ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
+      vars:
+        __sr_public: true
 
 - name: Test default - restore
   hosts: all

--- a/tests/tests_default_include.yml
+++ b/tests/tests_default_include.yml
@@ -10,8 +10,7 @@
       ansible.builtin.include_tasks: tasks/backup.yml
 
     - name: "Configure sshd"
-      ansible.builtin.include_role:
-        name: ansible-sshd
+      ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
 
     - name: "Restore configuration files"
       ansible.builtin.include_tasks: tasks/restore.yml

--- a/tests/tests_deprecated_sshd_variable.yml
+++ b/tests/tests_deprecated_sshd_variable.yml
@@ -10,8 +10,7 @@
       ansible.builtin.include_tasks: tasks/backup.yml
 
     - name: Configure sshd
-      ansible.builtin.include_role:
-        name: ansible-sshd
+      ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         sshd:
           AcceptEnv: LANG
@@ -70,13 +69,14 @@
     __sshd_test_backup_files:
       - /etc/ssh/sshd_config
       - /etc/ssh/sshd_config.d/00-ansible_system_role.conf
-  pre_tasks:
+  tasks:
     - name: "Backup configuration files"
       ansible.builtin.include_tasks: tasks/backup.yml
 
-  roles:
-    - role: ansible-sshd
+    - name: Configure sshd
+      ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
+        __sr_public: true
         sshd:
           AcceptEnv: LANG
           Banner: /etc/issue
@@ -84,7 +84,6 @@
           UseDNS: true
         sshd_config_file: /etc/ssh/sshd_config
 
-  tasks:
     - name: Verify the options are correctly set
       tags: tests::verify
       block:

--- a/tests/tests_duplicate_role.yml
+++ b/tests/tests_duplicate_role.yml
@@ -12,15 +12,13 @@
       ansible.builtin.include_tasks: tasks/backup.yml
 
     - name: Configure config1
-      ansible.builtin.include_role:
-        name: ansible-sshd
+      ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
 
 - name: Test duplicates - default config
   hosts: all
   tasks:
     - name: Configure default config
-      ansible.builtin.include_role:
-        name: ansible-sshd
+      ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
 
 - name: Test duplicates - setup config2
   hosts: all
@@ -28,9 +26,9 @@
     sshd_config_file: /etc/ssh/dup_config2
   tasks:
     - name: Configure config2
-      ansible.builtin.include_role:
-        name: ansible-sshd
-        public: true
+      ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
+      vars:
+        __sr_public: true
 
     - name: Convert exported variable to fact so that it is available in next plays
       ansible.builtin.set_fact:

--- a/tests/tests_firewall_selinux.yml
+++ b/tests/tests_firewall_selinux.yml
@@ -1,7 +1,6 @@
 ---
 - name: Test managing firewall and selinux from role
   hosts: all
-  gather_facts: true  # needs os_family, etc.
   vars:
     __sshd_test_backup_files:
       - /etc/ssh/sshd_config
@@ -13,9 +12,8 @@
     - name: Call role with no args to get access to __sshd_skip_virt_env
       ansible.builtin.include_role:
         name: ansible-sshd
+        tasks_from: variables.yml
         public: true
-      vars:
-        sshd_enable: false  # skip everything but loading vars
 
     - name: See if we can test firewall or selinux
       ansible.builtin.set_fact:
@@ -31,8 +29,7 @@
     # First test: default port
     ##########
     - name: Configure the role on default port and let it handle firewall settings
-      ansible.builtin.include_role:
-        name: ansible-sshd
+      ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         sshd_manage_selinux: "{{ __sshd_test_selinux }}"
         sshd_manage_firewall: "{{ __sshd_test_firewall }}"
@@ -60,8 +57,7 @@
     ##########
     # is this going to break some tests running ansible through ssh?
     - name: Configure the role on another port and let it handle firewall settings
-      ansible.builtin.include_role:
-        name: ansible-sshd
+      ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         sshd_manage_firewall: "{{ __sshd_test_firewall }}"
         sshd_manage_selinux: "{{ __sshd_test_selinux }}"
@@ -88,8 +84,7 @@
     # Third test: multiple ports
     ##########
     - name: Configure the role on several ports and let it handle firewall settings
-      ansible.builtin.include_role:
-        name: ansible-sshd
+      ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         sshd_manage_firewall: "{{ __sshd_test_firewall }}"
         sshd_manage_selinux: "{{ __sshd_test_selinux }}"

--- a/tests/tests_hostkeys.yml
+++ b/tests/tests_hostkeys.yml
@@ -28,8 +28,7 @@
         shell: /sbin/nologin
 
     - name: Configure sshd with alternative host keys
-      ansible.builtin.include_role:
-        name: ansible-sshd
+      ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         # very BAD example
         sshd_hostkey_owner: "nobody"

--- a/tests/tests_hostkeys_fips.yml
+++ b/tests/tests_hostkeys_fips.yml
@@ -13,8 +13,7 @@
       ansible.builtin.include_tasks: tasks/backup.yml
 
     - name: Run the role with default parameters without FIPS mode
-      ansible.builtin.include_role:
-        name: ansible-sshd
+      ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
 
     - name: Verify the options are correctly set
       when:
@@ -95,8 +94,7 @@
         state: absent
 
     - name: Run the role with default parameters
-      ansible.builtin.include_role:
-        name: ansible-sshd
+      ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
 
     - name: Verify the options are correctly set after reconfiguration
       when:

--- a/tests/tests_hostkeys_missing.yml
+++ b/tests/tests_hostkeys_missing.yml
@@ -10,15 +10,16 @@
     - name: "Backup configuration files"
       ansible.builtin.include_tasks: tasks/backup.yml
 
+    - name: Set fact for missing hostkey test block condition
+      ansible.builtin.set_fact:
+        __sshd_when_missing_hostkey_test: "{{ ansible_facts['os_family'] != 'Debian' and not (ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution_major_version'] == '6') }}"
+
     - name: Configure sshd with missing host keys and prevent their creation
-      when:
-        - ansible_facts['os_family'] != 'Debian'
-        - not (ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution_major_version'] == '6')
+      when: __sshd_when_missing_hostkey_test
       tags: tests::verify
       block:
         - name: Configure missing hostkey
-          ansible.builtin.include_role:
-            name: ansible-sshd
+          ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
           vars:
             sshd_verify_hostkeys: []
             sshd_config:

--- a/tests/tests_hostkeys_role.yml
+++ b/tests/tests_hostkeys_role.yml
@@ -30,8 +30,6 @@
 # invoke role through "roles"
 - name: Test hostkeys via role
   hosts: all
-  roles:
-    - ansible-sshd
   vars:
     # very BAD example
     sshd_hostkey_owner: "nobody"
@@ -40,6 +38,11 @@
     sshd_config:
       HostKey:
         - /tmp/ssh_host_rsa_key2
+  tasks:
+    - name: Run ansible-sshd role
+      ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
+      vars:
+        __sr_public: true
 
 - name: Test hostkeys via role - verify
   hosts: all

--- a/tests/tests_hostkeys_unsafe_path.yml
+++ b/tests/tests_hostkeys_unsafe_path.yml
@@ -33,8 +33,7 @@
         TMPDIR: "{{ __tmpdir }}"
       block:
         - name: Configure sshd with BAD config
-          ansible.builtin.include_role:
-            name: ansible-sshd
+          ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
           vars:
             sshd_skip_defaults: true
             sshd_verify_hostkeys: []

--- a/tests/tests_include_present.yml
+++ b/tests/tests_include_present.yml
@@ -20,8 +20,7 @@
           (ansible_facts['distribution'] == 'Ubuntu' and ansible_facts['distribution_major_version'] | int >= 20)
 
     - name: Create a new configuration in drop-in directory
-      ansible.builtin.include_role:
-        name: ansible-sshd
+      ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         sshd_config_file: /etc/ssh/sshd_config.d/00-ansible_system_role.conf
         sshd_config:
@@ -108,8 +107,7 @@
         mode: '0777'
 
     - name: Create a new configuration in a custom drop-in directory
-      ansible.builtin.include_role:
-        name: ansible-sshd
+      ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         sshd_config_file: /etc/ssh/custom_sshd_config.d/custom-drop-in
         sshd_main_config_file: /etc/ssh/custom_sshd_config

--- a/tests/tests_indent.yml
+++ b/tests/tests_indent.yml
@@ -10,8 +10,7 @@
       ansible.builtin.include_tasks: tasks/backup.yml
 
     - name: Configure sshd with simple config options
-      ansible.builtin.include_role:
-        name: ansible-sshd
+      ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         sshd_config:
           PasswordAuthentication: true

--- a/tests/tests_match.yml
+++ b/tests/tests_match.yml
@@ -10,8 +10,7 @@
       ansible.builtin.include_tasks: tasks/backup.yml
 
     - name: Configure sshd
-      ansible.builtin.include_role:
-        name: ansible-sshd
+      ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         # For Fedora containers, we need to make sure we have keys for sshd -T below
         sshd_verify_hostkeys:

--- a/tests/tests_match_iterate.yml
+++ b/tests/tests_match_iterate.yml
@@ -10,8 +10,7 @@
       ansible.builtin.include_tasks: tasks/backup.yml
 
     - name: Configure sshd
-      ansible.builtin.include_role:
-        name: ansible-sshd
+      ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         # For Fedora containers, we need to make sure we have keys for sshd -T below
         sshd_verify_hostkeys:

--- a/tests/tests_os_defaults.yml
+++ b/tests/tests_os_defaults.yml
@@ -26,9 +26,9 @@
       changed_when: false
 
     - name: Configure sshd
-      ansible.builtin.include_role:
-        name: ansible-sshd
-        public: true
+      ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
+      vars:
+        __sr_public: true
 
     - name: Show effective configuration after running role (role defaults)
       ansible.builtin.command: sshd -T

--- a/tests/tests_precedence.yml
+++ b/tests/tests_precedence.yml
@@ -16,8 +16,7 @@
         state: absent
 
     - name: Configure sshd  # noqa var-naming
-      ansible.builtin.include_role:
-        name: ansible-sshd
+      ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         sshd_config:
           Banner: /etc/issue

--- a/tests/tests_runtime_directory.yml
+++ b/tests/tests_runtime_directory.yml
@@ -16,8 +16,7 @@
       ansible.builtin.include_tasks: tasks/backup.yml
 
     - name: Configure sshd with default options and install service
-      ansible.builtin.include_role:
-        name: ansible-sshd
+      ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         sshd_install_service: true
 

--- a/tests/tests_second_service.yml
+++ b/tests/tests_second_service.yml
@@ -27,8 +27,7 @@
         mode: '0755'
 
     - name: Configure alternative sshd_config file
-      ansible.builtin.include_role:
-        name: ansible-sshd
+      ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         sshd_service: sshd2
         sshd_config_file: /etc/ssh2/sshd_config

--- a/tests/tests_second_service_drop_in.yml
+++ b/tests/tests_second_service_drop_in.yml
@@ -14,10 +14,12 @@
     - name: "Backup configuration files"
       ansible.builtin.include_tasks: tasks/backup.yml
 
+    - name: Set fact for second service drop-in test availability
+      ansible.builtin.set_fact:
+        __sshd_when_second_service_drop_in: "{{ (ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution_major_version'] | int > 8) or (ansible_facts['distribution'] == 'Ubuntu' and ansible_facts['distribution_major_version'] | int >= 20) }}"
+
     - name: Run the test
-      when:
-        - (ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution_major_version'] | int > 8) or
-          (ansible_facts['distribution'] == 'Ubuntu' and ansible_facts['distribution_major_version'] | int >= 20)
+      when: __sshd_when_second_service_drop_in
       block:
         - name: Create ssh2 directory
           ansible.builtin.file:
@@ -32,8 +34,7 @@
             mode: '0600'
 
         - name: Configure alternative sshd_config file
-          ansible.builtin.include_role:
-            name: ansible-sshd
+          ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
           vars:
             sshd_service: sshd2
             sshd_main_config_file: /etc/ssh2/sshd_config

--- a/tests/tests_set_common.yml
+++ b/tests/tests_set_common.yml
@@ -10,8 +10,7 @@
       ansible.builtin.include_tasks: tasks/backup.yml
 
     - name: Configure sshd
-      ansible.builtin.include_role:
-        name: ansible-sshd
+      ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         sshd_config:
           AcceptEnv: LANG

--- a/tests/tests_set_uncommon.yml
+++ b/tests/tests_set_uncommon.yml
@@ -9,13 +9,15 @@
     - name: "Backup configuration files"
       ansible.builtin.include_tasks: tasks/backup.yml
 
+    - name: Set fact for uncommon options test block condition
+      ansible.builtin.set_fact:
+        __sshd_when_uncommon_options_test: "{{ not (ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution_major_version'] == '6') }}"
+
     - name: Configure sshd with uncommon options, making sure it keeps running
-      when:
-        - not (ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution_major_version'] == '6')
+      when: __sshd_when_uncommon_options_test
       block:
         - name: Configure ssh with unsupported options
-          ansible.builtin.include_role:
-            name: ansible-sshd
+          ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
           vars:
             sshd_config:
               # Unsupported in new versions, but ignored ?

--- a/tests/tests_sshd_enable.yml
+++ b/tests/tests_sshd_enable.yml
@@ -12,8 +12,7 @@
       ansible.builtin.include_tasks: tasks/backup.yml
 
     - name: Configure sshd with the role disabled
-      ansible.builtin.include_role:
-        name: ansible-sshd
+      ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         sshd_enable: false
         sshd_config:

--- a/tests/tests_sysconfig.yml
+++ b/tests/tests_sysconfig.yml
@@ -11,8 +11,7 @@
       ansible.builtin.include_tasks: tasks/backup.yml
 
     - name: Configure sshd
-      ansible.builtin.include_role:
-        name: ansible-sshd
+      ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         sshd_sysconfig: true
         sshd_sysconfig_override_crypto_policy: true

--- a/tests/tests_systemd_services.yml
+++ b/tests/tests_systemd_services.yml
@@ -26,8 +26,7 @@
       ansible.builtin.include_tasks: tasks/backup.yml
 
     - name: Configure sshd with default options and install service files
-      ansible.builtin.include_role:
-        name: ansible-sshd
+      ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         sshd_install_service: true
 

--- a/tests/tests_systemd_socket_listen.yml
+++ b/tests/tests_systemd_socket_listen.yml
@@ -26,8 +26,7 @@
       ansible.builtin.include_tasks: tasks/backup.yml
 
     - name: Configure sshd with default options and install service files
-      ansible.builtin.include_role:
-        name: ansible-sshd
+      ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         sshd_install_service: true
         sshd_config:

--- a/tests/tests_systemd_socket_port.yml
+++ b/tests/tests_systemd_socket_port.yml
@@ -26,8 +26,7 @@
       ansible.builtin.include_tasks: tasks/backup.yml
 
     - name: Configure sshd with default options and install service files
-      ansible.builtin.include_role:
-        name: ansible-sshd
+      ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         sshd_install_service: true
         sshd_config:

--- a/tests/tests_unsafe_options.yml
+++ b/tests/tests_unsafe_options.yml
@@ -13,8 +13,7 @@
     - name: Configure sshd with bad sysconfig configuration
       block:
         - name: Include the role
-          ansible.builtin.include_role:
-            name: ansible-sshd
+          ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
           vars:
             sshd_skip_defaults: true
             sshd_verify_hostkeys: []
@@ -36,8 +35,7 @@
     - name: Configure sshd with bad path to sshd binary
       block:
         - name: Include the role
-          ansible.builtin.include_role:
-            name: ansible-sshd
+          ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
           vars:
             sshd_skip_defaults: true
             sshd_verify_hostkeys: []
@@ -59,8 +57,7 @@
     - name: Configure sshd with bad path sshd config
       block:
         - name: Include the role
-          ansible.builtin.include_role:
-            name: ansible-sshd
+          ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
           vars:
             sshd_skip_defaults: true
             sshd_verify_hostkeys: []

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -27,7 +27,10 @@ __sshd_hostkeys_nofips: []
 __sshd_required_facts:
   - distribution
   - distribution_major_version
+  - distribution_version
   - os_family
+  - service_mgr
+  - virtualization_type
 
 __sshd_skip_virt_env:
   - docker


### PR DESCRIPTION
The role gathers the facts it uses.  For example, if the user uses
`ANSIBLE_GATHERING=explicit`, the role uses the `setup` module with the
facts and subsets it requires.

This change allows us to test this.  Before every role invocation, the test
will use `meta: clear_facts` so that the role starts with no facts.

Create a task file tests/tasks/run_role_with_clear_facts.yml to do the tasks
to clear the facts and run the role.  Note that this means we don't need to
use `gather_facts` for the tests.

Some vars defined using `ansible_facts` have been changed to be defined with
`set_fact` instead.  This is because of the fact that `vars` are lazily
evaluated - the var might be referenced when the facts have been cleared, and
will issue an error like `ansible_facts["distribution"] is undefined`.  This is
typically done for blocks that have a `when` condition that uses `ansible_facts`
and the block has a role invocation using run_role_with_clear_facts.yml
These have been rewritten to define the `when` condition using `set_fact`.  This
is because the `when` condition is evaluated every time a task is invoked in the
block, and if the facts are cleared, this will raise an undefined variable error.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
