### PR TITLE
feat: Add new c10s options GSSAPIAllowS4U2Self and GSSAPIProxyS4U2Services

### DIFF
--- a/meta/options_body
+++ b/meta/options_body
@@ -36,6 +36,7 @@ ExposeAuthInfo
 FingerprintHash
 ForceCommand
 GatewayPorts
+GSSAPIAllowS4U2Self
 GSSAPIAuthentication
 GSSAPICleanupCredentials
 GSSAPIDelegateCredentials
@@ -43,6 +44,7 @@ GSSAPIEnablek5users
 GSSAPIIndicators
 GSSAPIKeyExchange
 GSSAPIKexAlgorithms
+GSSAPIProxyS4U2Services
 GSSAPIStoreCredentialsOnRekey
 GSSAPIStrictAcceptorCheck
 HPNBufferSize

--- a/templates/sshd_config.j2
+++ b/templates/sshd_config.j2
@@ -169,6 +169,7 @@ Match {{ match["Condition"] }}
 {{ body_option("FingerprintHash",sshd_FingerprintHash) -}}
 {{ body_option("ForceCommand",sshd_ForceCommand) -}}
 {{ body_option("GatewayPorts",sshd_GatewayPorts) -}}
+{{ body_option("GSSAPIAllowS4U2Self",sshd_GSSAPIAllowS4U2Self) -}}
 {{ body_option("GSSAPIAuthentication",sshd_GSSAPIAuthentication) -}}
 {{ body_option("GSSAPICleanupCredentials",sshd_GSSAPICleanupCredentials) -}}
 {{ body_option("GSSAPIDelegateCredentials",sshd_GSSAPIDelegateCredentials) -}}
@@ -176,6 +177,7 @@ Match {{ match["Condition"] }}
 {{ body_option("GSSAPIIndicators",sshd_GSSAPIIndicators) -}}
 {{ body_option("GSSAPIKeyExchange",sshd_GSSAPIKeyExchange) -}}
 {{ body_option("GSSAPIKexAlgorithms",sshd_GSSAPIKexAlgorithms) -}}
+{{ body_option("GSSAPIProxyS4U2Services",sshd_GSSAPIProxyS4U2Services) -}}
 {{ body_option("GSSAPIStoreCredentialsOnRekey",sshd_GSSAPIStoreCredentialsOnRekey) -}}
 {{ body_option("GSSAPIStrictAcceptorCheck",sshd_GSSAPIStrictAcceptorCheck) -}}
 {{ body_option("HPNBufferSize",sshd_HPNBufferSize) -}}

--- a/templates/sshd_config_snippet.j2
+++ b/templates/sshd_config_snippet.j2
@@ -167,6 +167,7 @@ Match {{ match["Condition"] }}
 {{ body_option("FingerprintHash",sshd_FingerprintHash) -}}
 {{ body_option("ForceCommand",sshd_ForceCommand) -}}
 {{ body_option("GatewayPorts",sshd_GatewayPorts) -}}
+{{ body_option("GSSAPIAllowS4U2Self",sshd_GSSAPIAllowS4U2Self) -}}
 {{ body_option("GSSAPIAuthentication",sshd_GSSAPIAuthentication) -}}
 {{ body_option("GSSAPICleanupCredentials",sshd_GSSAPICleanupCredentials) -}}
 {{ body_option("GSSAPIDelegateCredentials",sshd_GSSAPIDelegateCredentials) -}}
@@ -174,6 +175,7 @@ Match {{ match["Condition"] }}
 {{ body_option("GSSAPIIndicators",sshd_GSSAPIIndicators) -}}
 {{ body_option("GSSAPIKeyExchange",sshd_GSSAPIKeyExchange) -}}
 {{ body_option("GSSAPIKexAlgorithms",sshd_GSSAPIKexAlgorithms) -}}
+{{ body_option("GSSAPIProxyS4U2Services",sshd_GSSAPIProxyS4U2Services) -}}
 {{ body_option("GSSAPIStoreCredentialsOnRekey",sshd_GSSAPIStoreCredentialsOnRekey) -}}
 {{ body_option("GSSAPIStrictAcceptorCheck",sshd_GSSAPIStrictAcceptorCheck) -}}
 {{ body_option("HPNBufferSize",sshd_HPNBufferSize) -}}


### PR DESCRIPTION
Enhancement: Add new configuration options GSSAPIAllowS4U2Self and GSSAPIProxyS4U2Services.

Reason: The CentOS 10 Stream and Fedora got a new configuration options GSSAPIAllowS4U2Self and GSSAPIProxyS4U2Services that need to be handled in this role.

Result: User are able to configure the new configuration options with this role.

Issue Tracker Tickets (Jira or BZ if any): -
