### PR TITLE
chore: adding the default include for leap

### DIFF
--- a/vars/openSUSE Leap_15.yml
+++ b/vars/openSUSE Leap_15.yml
@@ -3,6 +3,7 @@ __sshd_packages:
   - openssh
 __sshd_sftp_server: /usr/lib/ssh/sftp-server
 __sshd_defaults:
+  Include: /usr/etc/ssh/sshd_config.d/*.conf
   AuthorizedKeysFile: .ssh/authorized_keys
   UsePAM: true
   X11Forwarding: true


### PR DESCRIPTION
Enhancement: The default include line is removed when this role is executed.

Reason: I suppose it is handy to keep it, since the distro uses it to set crypto policies.

Result:
In a `podman run -it docker.io/geerlingguy/docker-opensuseleap15-ansible:latest bash` container, I ran these commands after installing sshd.

```
9e8a3eb0c81e:/ # grep -r Include /etc/ssh/*
/etc/ssh/sshd_config:Include /etc/ssh/sshd_config.d/*.conf
/etc/ssh/sshd_config:Include /usr/etc/ssh/sshd_config.d/*.conf
/etc/ssh/sshd_config.d/40-suse-crypto-policies.conf:Include /etc/crypto-policies/back-ends/opensshserver.config

9e8a3eb0c81e:/ # cat /etc/os-release 
NAME="openSUSE Leap"
VERSION="15.6"
ID="opensuse-leap"
ID_LIKE="suse opensuse"
VERSION_ID="15.6"
PRETTY_NAME="openSUSE Leap 15.6"
ANSI_COLOR="0;32"
CPE_NAME="cpe:/o:opensuse:leap:15.6"
BUG_REPORT_URL="https://bugs.opensuse.org"
HOME_URL="https://www.opensuse.org/"
DOCUMENTATION_URL="https://en.opensuse.org/Portal:Leap"
LOGO="distributor-logo-Leap"

9e8a3eb0c81e:/ # rpm -qc openssh-server
/etc/pam.d/sshd
/etc/slp.reg.d/ssh.reg
/etc/ssh/sshd_config
/etc/ssh/sshd_config.d/40-suse-crypto-policies.conf
/etc/sysconfig/SuSEfirewall2.d/services/sshd
```

This include line is there, but not in the config itself for LEAP.

Issue Tracker Tickets (Jira or BZ if any):
