### PR TITLE
feat: Add verbosity-based logging to reduce verbose output

### DIFF
--- a/tasks/install_service.yml
+++ b/tasks/install_service.yml
@@ -51,6 +51,7 @@
     - sshd_manage_service|bool
     - ansible_facts['virtualization_type'] | default(None) not in __sshd_skip_virt_env
     - ansible_connection != 'chroot'
+  no_log: "{{ ansible_verbosity < 3 }}"
 
 # Due to ansible bug 21026, cannot use service module on RHEL 7
 - name: Enable service in chroot

--- a/tasks/variables.yml
+++ b/tasks/variables.yml
@@ -6,6 +6,7 @@
       - virtual
   when: __sshd_required_facts |
     difference(ansible_facts.keys() | list) | length > 0
+  no_log: "{{ ansible_verbosity < 3 }}"
 
 - name: Record role begin fingerprint
   sr_fingerprint:


### PR DESCRIPTION
Enhancement: Add verbosity-based logging using \`no_log: "{{ ansible_verbosity < 3 }}"\` to reduce verbose output from fact gathering and service management tasks.

Reason: The setup task (fact gathering) and service task (enabling/starting sshd) can produce verbose output that clutters logs during normal playbook execution. This output is useful for debugging but creates noise in standard runs.

Result: By using \`ansible_verbosity < 3\`, the output from these tasks is suppressed by default but can be shown when running with \`-vvv\` or higher verbosity for debugging purposes. This improves log readability while maintaining full debugging capabilities when needed.

Note: This is for verbosity control, not for security purposes - there's no sensitive information being hidden, just reducing noise in normal operation.