### PR TITLE
test: ensure fips_enabled bind mount is removed from fstab

### DIFF
--- a/tests/tests_hostkeys_fips.yml
+++ b/tests/tests_hostkeys_fips.yml
@@ -136,7 +136,7 @@
         - name: Unmount the file
           ansible.posix.mount:
             path: /proc/sys/crypto/fips_enabled
-            state: unmounted
+            state: absent
           failed_when: false
 
         - name: Remove the temporary directory


### PR DESCRIPTION
The test was leaving the fips_enabled bind mount in /etc/fstab.
Use `state: absent` to both unmount the path and remove from fstab.
https://docs.ansible.com/projects/ansible/latest/collections/ansible/posix/mount_module.html#parameter-state

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
