### PR TITLE
test: have to use yum for EL7 tests

### DIFF
--- a/.github/workflows/ansible-check.yml
+++ b/.github/workflows/ansible-check.yml
@@ -10,20 +10,33 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os_image:
-          - alpine:latest
-          - quay.io/centos/centos:stream8
-          - quay.io/centos/centos:stream9
-          - quay.io/centos/centos:stream10
-          - debian:bullseye
-          - debian:bookworm
-          - debian:latest
-          - fedora:latest
-          - ubuntu:22.04
-          - ubuntu:24.04
-          - ubuntu:latest
-          # - opensuse/tumbleweed:latest # too odd
-          - opensuse/leap:latest
+        scenario:
+          - os_image: alpine:latest
+            req_file: tests/requirements.yml
+          - os_image: quay.io/centos/centos:stream8
+            req_file: tests/requirements.yml
+          - os_image: quay.io/centos/centos:stream9
+            req_file: tests/requirements.yml
+          - os_image: quay.io/centos/centos:stream10
+            req_file: tests/requirements.yml
+          - os_image: debian:bullseye
+            req_file: tests/requirements-no-fedora-lsr.yml
+          - os_image: debian:bookworm
+            req_file: tests/requirements.yml
+          - os_image: debian:latest
+            req_file: tests/requirements.yml
+          - os_image: fedora:latest
+            req_file: tests/requirements.yml
+          - os_image: ubuntu:22.04
+            req_file: tests/requirements-no-fedora-lsr.yml
+          - os_image: ubuntu:24.04
+            req_file: tests/requirements.yml
+          - os_image: ubuntu:latest
+            req_file: tests/requirements.yml
+          # - os_image: opensuse/tumbleweed:latest # too odd
+          #   req_file: tests/requirements.yml
+          - os_image: opensuse/leap:latest
+            req_file: tests/requirements-no-fedora-lsr.yml
 
     steps:
       - name: Checkout code
@@ -32,8 +45,8 @@ jobs:
       - name: Test Ansible SSHD Role
         uses: Jakuje/check-ansible-action@main
         with:
-          image: ${{ matrix.os_image }}
+          image: ${{ matrix.scenario.os_image }}
           group: local
           hosts: localhost
           targets: "tests/tests_*.yml"
-          requirements: tests/requirements.yml
+          requirements: ${{ matrix.scenario.req_file }}

--- a/.github/workflows/ansible-check.yml
+++ b/.github/workflows/ansible-check.yml
@@ -35,8 +35,8 @@ jobs:
             req_file: tests/requirements.yml
           # - os_image: opensuse/tumbleweed:latest # too odd
           #   req_file: tests/requirements.yml
-          - os_image: opensuse/leap:latest
-            req_file: tests/requirements-no-fedora-lsr.yml
+          # - os_image: opensuse/leap:latest  # can't find python3
+          #  req_file: tests/requirements-no-fedora-lsr.yml
 
     steps:
       - name: Checkout code

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.4.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.20.0"
       - name: Convert role to collection format
         id: collection
         run: |

--- a/tests/requirements-no-fedora-lsr.yml
+++ b/tests/requirements-no-fedora-lsr.yml
@@ -1,0 +1,3 @@
+---
+collections:
+  - name: ansible.posix

--- a/tests/tests_all_options.yml
+++ b/tests/tests_all_options.yml
@@ -25,7 +25,7 @@
       when: ansible_facts['distribution'] == "openSUSE Tumbleweed"
 
     - name: Reinstall manual pages for openssh-server on RHEL
-      ansible.builtin.command: "dnf reinstall -y openssh-server"
+      ansible.builtin.command: "{{ pkg_mgr | quote }} reinstall -y openssh-server"
       when:
         - ansible_facts['os_family'] == "RedHat"
         - not __sshd_is_ostree | d(false)

--- a/tests/tests_all_options.yml
+++ b/tests/tests_all_options.yml
@@ -25,7 +25,7 @@
       when: ansible_facts['distribution'] == "openSUSE Tumbleweed"
 
     - name: Reinstall manual pages for openssh-server on RHEL
-      ansible.builtin.command: "{{ pkg_mgr | quote }} reinstall -y openssh-server"
+      ansible.builtin.command: "{{ ansible_facts['pkg_mgr'] | quote }} reinstall -y openssh-server"
       when:
         - ansible_facts['os_family'] == "RedHat"
         - not __sshd_is_ostree | d(false)


### PR DESCRIPTION
Using `dnf` here causes test failures on EL7.  Revert to use `pkg_mgr`
in order to use `yum` on EL7, `dnf` elsewehre.

Update tox-lsr to 3.20.0 to fix issues with tox 4.58

Use `ansible_facts["pkg_mgr"]` instead of `pkg_mgr`

Do not install `fedora.linux_system_roles` on platforms that do not use it for testing

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
